### PR TITLE
Support for JDK 9, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: java
 jdk:
 - oraclejdk8
+- oraclejdk9
+- openjdk10
+- openjdk11
 install: true
 script: mvn -fae -U -B clean install -P check
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 jdk:
 - oraclejdk8
 - oraclejdk9
-- openjdk10
+- oraclejdk10
 - openjdk11
 install: true
 script: mvn -fae -U -B clean install -P check

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: java
 jdk:
 - oraclejdk8
 - oraclejdk9
+- openjdk8
+- openjdk9
 - openjdk10
 - openjdk11
 install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 jdk:
 - openjdk8
-- openjdk9
 - openjdk11
 install: true
 script: mvn -fae -U -B clean install -P check
@@ -18,6 +17,10 @@ notifications:
       secure: HdORchpRBg2B2XdamwsWh2GDtKbk0+PuGPaqfgW+mhUa0pkZmFrpUDc9NXPjwPiosBd/Xn2PhuFPBhP8UqGj5jvxOSnMed0lsJ6z1EbnbeGXQ1zRrQ5EtWwfoGao2TnteFfjc8aQHkV3q0IYWwELjUuOta2gS9CFaQiyRODVFpwOl/73ddCfgJgONDjaAjIKGeuWMcS2UUY6BjdnX+k0kBC5jzk/yYs85U+kQ4ZQ6SPLueRIDZH/zrtmaAzLzlrmzIDneypls+W2jPa79CYch9spFNEh7Rq+Y3EKN3/WmTVydQiucuPr0BDqcTx1BYrNCQOTKvBZJB9I5IOKay0/o/ZL4rYgE7yqnVsBmZc9Ir19BxZp4CrwjX/hI2hTP7BXT2jgoidepUba6wUn1TLt5cUgIx215nCsRTiIi+pkNa0hvLHufG9tZC2OvFczAngdducI/zv+oMT6acQD5V0gERxsb7lboudkcNLfMPPmlnO+T+FuO73k9Bhf7O0/kGpKmS3JBk/ZXfNaGHthvB3MAvtba+BrAgxI5pZxkritmu+iE/s10bbiOAIZXRZDHaJBvvVtMJLpHBJS82BTe3jja5Imi/E9R75DHzhl41I8hv0+nNa5xS8+y6SJnm2Y9kAO+YWVl+8zRDIHmNkMUGqbaLM34NOwFtMsHdhyH3TQQcw=
 matrix:
   include:
+    - jdk: openjdk9
+      before_install:
+        - rm "${JAVA_HOME}/lib/security/cacerts"
+        - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"
     - jdk: openjdk10
       before_install:
         - rm "${JAVA_HOME}/lib/security/cacerts"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 jdk:
 - oraclejdk8
 - oraclejdk9
-- oraclejdk10
+- openjdk10
 - openjdk11
 install: true
 script: mvn -fae -U -B clean install -P check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: java
 jdk:
-- oraclejdk8
-- oraclejdk9
 - openjdk8
 - openjdk9
 - openjdk10
@@ -19,3 +17,9 @@ notifications:
   slack:
     rooms:
       secure: HdORchpRBg2B2XdamwsWh2GDtKbk0+PuGPaqfgW+mhUa0pkZmFrpUDc9NXPjwPiosBd/Xn2PhuFPBhP8UqGj5jvxOSnMed0lsJ6z1EbnbeGXQ1zRrQ5EtWwfoGao2TnteFfjc8aQHkV3q0IYWwELjUuOta2gS9CFaQiyRODVFpwOl/73ddCfgJgONDjaAjIKGeuWMcS2UUY6BjdnX+k0kBC5jzk/yYs85U+kQ4ZQ6SPLueRIDZH/zrtmaAzLzlrmzIDneypls+W2jPa79CYch9spFNEh7Rq+Y3EKN3/WmTVydQiucuPr0BDqcTx1BYrNCQOTKvBZJB9I5IOKay0/o/ZL4rYgE7yqnVsBmZc9Ir19BxZp4CrwjX/hI2hTP7BXT2jgoidepUba6wUn1TLt5cUgIx215nCsRTiIi+pkNa0hvLHufG9tZC2OvFczAngdducI/zv+oMT6acQD5V0gERxsb7lboudkcNLfMPPmlnO+T+FuO73k9Bhf7O0/kGpKmS3JBk/ZXfNaGHthvB3MAvtba+BrAgxI5pZxkritmu+iE/s10bbiOAIZXRZDHaJBvvVtMJLpHBJS82BTe3jja5Imi/E9R75DHzhl41I8hv0+nNa5xS8+y6SJnm2Y9kAO+YWVl+8zRDIHmNkMUGqbaLM34NOwFtMsHdhyH3TQQcw=
+matrix:
+  include:
+    - jdk: openjdk10
+      before_install:
+        - rm "${JAVA_HOME}/lib/security/cacerts"
+        - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: java
 jdk:
 - openjdk8
 - openjdk9
-- openjdk10
 - openjdk11
 install: true
 script: mvn -fae -U -B clean install -P check

--- a/NOTICE
+++ b/NOTICE
@@ -45,6 +45,7 @@ This project includes:
   Apache Commons IO under Apache License, Version 2.0
   Apache HttpClient under Apache License, Version 2.0
   Apache HttpCore under Apache License, Version 2.0
+  Checker Qual under GNU General Public License, version 2 (GPL2), with the classpath exception or The MIT License
   Commons Lang under The Apache Software License, Version 2.0
   Compress-LZF under Apache License 2.0
   Elasticsearch SecureSM under The Apache Software License, Version 2.0
@@ -80,6 +81,7 @@ This project includes:
   Jackson-core under The Apache Software License, Version 2.0
   jackson-databind under The Apache Software License, Version 2.0
   Jackson-dataformat-YAML under The Apache Software License, Version 2.0
+  Java Architecture for XML Binding under CDDL 1.1 or GPL2 w/ CPE
   JavaBeans(TM) Activation Framework under COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0
   JavaMail API jar under CDDL or GPLv2+CE
   javax.inject under The Apache Software License, Version 2.0
@@ -144,6 +146,8 @@ This project includes:
   OGC WaterML DR schema (spec. v2.0) under The Apache Software License, Version 2.0
   OGC WaterML schema (spec. v2.0) under The Apache Software License, Version 2.0
   OGC XML schemas under The Apache Software License, Version 2.0
+  Old JAXB Core under CDDL+GPL License
+  Old JAXB Runtime under CDDL+GPL License
   org.locationtech.jts:jts-core under Eclipse Publish License, Version 1.0 or Eclipse Distribution License - v 1.0
   Portele Schape Change schema (spec. v3.0) under The Apache Software License, Version 2.0
   Saxon-HE under Mozilla Public License Version 2.0

--- a/NOTICE
+++ b/NOTICE
@@ -45,7 +45,7 @@ This project includes:
   Apache Commons IO under Apache License, Version 2.0
   Apache HttpClient under Apache License, Version 2.0
   Apache HttpCore under Apache License, Version 2.0
-  Checker Qual under GNU General Public License, version 2 (GPL2), with the classpath exception or The MIT License
+  Checker Qual under The MIT License
   Commons Lang under The Apache Software License, Version 2.0
   Compress-LZF under Apache License 2.0
   Elasticsearch SecureSM under The Apache Software License, Version 2.0
@@ -57,6 +57,8 @@ This project includes:
   FindBugs-jsr305 under The Apache Software License, Version 2.0
   Geographic Common (GCO) schema (version 2012-07-13) under The Apache Software License, Version 2.0
   Geographic MetaData (GMD) schema (version 2012-07-13) under The Apache Software License, Version 2.0
+  Guava InternalFutureFailureAccess and InternalFutures under The Apache Software License, Version 2.0
+  Guava ListenableFuture only under The Apache Software License, Version 2.0
   Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0
   HdrHistogram under Public Domain, per Creative Commons CC0
   HPPC Collections under The Apache Software License, Version 2.0

--- a/iceland/core/pom.xml
+++ b/iceland/core/pom.xml
@@ -197,4 +197,34 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>since-jdk9</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <dependencies>
+                            <dependency>
+                                <groupId>javax.xml.soap</groupId>
+                                <artifactId>javax.xml.soap-api</artifactId>
+                                <version>${version.javax-xml-soap}</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+            </build>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.xml.soap</groupId>
+                    <artifactId>javax.xml.soap-api</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/iceland/core/src/main/java/org/n52/iceland/binding/AbstractXmlBinding.java
+++ b/iceland/core/src/main/java/org/n52/iceland/binding/AbstractXmlBinding.java
@@ -26,6 +26,12 @@ import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+
 import org.n52.iceland.coding.DocumentBuilderProvider;
 import org.n52.iceland.coding.decode.OwsDecodingException;
 import org.n52.iceland.util.http.HttpUtils;
@@ -44,11 +50,6 @@ import org.n52.svalbard.decode.DecoderKey;
 import org.n52.svalbard.decode.XmlNamespaceOperationDecoderKey;
 import org.n52.svalbard.decode.XmlStringOperationDecoderKey;
 import org.n52.svalbard.decode.exception.DecodingException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.xml.sax.SAXException;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
@@ -155,7 +156,7 @@ public abstract class AbstractXmlBinding<T> extends SimpleBinding {
                 elementName = splittedNodeName[0];
             }
             // TODO get namespace for prefix
-            if (Strings.isNullOrEmpty(prefix)) {
+            if (prefix == null || prefix.isEmpty()) {
                 name = W3CConstants.AN_XMLNS;
             } else {
                 name = W3CConstants.PREFIX_XMLNS + prefix;

--- a/iceland/core/src/main/java/org/n52/iceland/util/AbstractPropertyFileHandler.java
+++ b/iceland/core/src/main/java/org/n52/iceland/util/AbstractPropertyFileHandler.java
@@ -30,6 +30,8 @@ import org.slf4j.LoggerFactory;
 
 import org.n52.faroe.ConfigurationError;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * @since 1.0.0
  *
@@ -51,13 +53,14 @@ public class AbstractPropertyFileHandler {
         this.propertiesFile = file;
     }
 
+    @SuppressFBWarnings(value = "OBL_UNSATISFIED_OBLIGATION", justification = "false positive")
     protected Properties load() throws IOException {
         if (this.cache == null) {
             File f = getFile(false);
             if (f == null) {
                 return new Properties();
             }
-            try (InputStream is = new FileInputStream(getFile(true))) {
+            try (InputStream is = new FileInputStream(f)) {
                 Properties p = new Properties();
                 p.load(is);
                 cache = p;
@@ -66,6 +69,7 @@ public class AbstractPropertyFileHandler {
         return cache;
     }
 
+    @SuppressFBWarnings(value = "OBL_UNSATISFIED_OBLIGATION", justification = "false positive")
     protected void save(Properties p) throws IOException {
         try (OutputStream os = new FileOutputStream(getFile(true))) {
             p.store(os, null);
@@ -139,7 +143,7 @@ public class AbstractPropertyFileHandler {
         lock.writeLock().lock();
         try {
             Properties p = load();
-            properties.stringPropertyNames().forEach(key -> p.setProperty(key, properties.getProperty(key)));
+            copyTo(properties, p);
             save(p);
         } catch (IOException e) {
             throw new ConfigurationError(ERROR_WRITING_MESSAGE, e);
@@ -172,9 +176,14 @@ public class AbstractPropertyFileHandler {
         }
     }
 
+    private static void copyTo(Properties source, Properties target) {
+        source.stringPropertyNames()
+                .forEach(key -> target.setProperty(key, source.getProperty(key)));
+    }
+
     private static Properties copyOf(Properties p) {
         Properties np = new Properties();
-        p.stringPropertyNames().forEach(s -> np.put(s, p.get(s)));
+        copyTo(p, np);
         return np;
     }
 }

--- a/iceland/core/src/test/java/org/n52/iceland/i18n/I18NSerializerTest.java
+++ b/iceland/core/src/test/java/org/n52/iceland/i18n/I18NSerializerTest.java
@@ -61,7 +61,7 @@ public class I18NSerializerTest {
     private void test(MultilingualString string) {
         errors.checkThat(string, is(notNullValue()));
         String encoded = new I18NSerializer().encode(string);
-        System.out.println(encoded);
+        //System.out.println(encoded);
         errors.checkThat(encoded.isEmpty(), is(string.isEmpty()));
         MultilingualString decoded = new I18NSerializer().decode(encoded);
         errors.checkThat(decoded, is(equalTo(string)));

--- a/iceland/statistics/core/pom.xml
+++ b/iceland/statistics/core/pom.xml
@@ -83,6 +83,10 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>

--- a/iceland/statistics/core/src/main/java/org/n52/iceland/statistics/api/utils/FileDownloader.java
+++ b/iceland/statistics/core/src/main/java/org/n52/iceland/statistics/api/utils/FileDownloader.java
@@ -30,6 +30,8 @@ import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 public final class FileDownloader {
 
     private static final Logger LOG = LoggerFactory.getLogger(FileDownloader.class);
@@ -56,6 +58,7 @@ public final class FileDownloader {
         FileUtils.copyURLToFile(fileUrl, out);
     }
 
+    @SuppressFBWarnings("OBL_UNSATISFIED_OBLIGATION")
     public static void gunzipFile(String filePath) throws IOException {
         File file = new File(filePath);
         String outPath = null;

--- a/iceland/statistics/core/src/main/java/org/n52/iceland/statistics/impl/ElasticsearchAdminHandler.java
+++ b/iceland/statistics/core/src/main/java/org/n52/iceland/statistics/impl/ElasticsearchAdminHandler.java
@@ -235,7 +235,7 @@ public class ElasticsearchAdminHandler implements IAdminDataHandler {
                 try {
                     String[] split = i.split(":");
                     address = new InetSocketTransportAddress(InetAddress.getByName(split[0]),
-                                                             Integer.valueOf(split[1]));
+                                                             Integer.parseInt(split[1]));
                 } catch (UnknownHostException e) {
                     logConnectionError(i, e);
                 }

--- a/iceland/statistics/core/src/main/java/org/n52/iceland/statistics/impl/server/EmbeddedElasticsearch.java
+++ b/iceland/statistics/core/src/main/java/org/n52/iceland/statistics/impl/server/EmbeddedElasticsearch.java
@@ -38,6 +38,8 @@ import org.n52.iceland.statistics.api.utils.FileDownloader;
 
 import com.google.common.collect.ImmutableList;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 public class EmbeddedElasticsearch {
 
     private static final Logger LOG = LoggerFactory.getLogger(EmbeddedElasticsearch.class);
@@ -62,6 +64,7 @@ public class EmbeddedElasticsearch {
         }
     }
 
+    @SuppressFBWarnings("OBL_UNSATISFIED_OBLIGATION")
     public void init() {
         Objects.requireNonNull(homePath);
 
@@ -84,7 +87,7 @@ public class EmbeddedElasticsearch {
         String resource = RESOURCE_BASE + CONFIG_PATH;
         Builder setting;
         try (InputStream stream = getClass().getResourceAsStream(RESOURCE_BASE + CONFIG_PATH)) {
-            setting = Settings.settingsBuilder() .loadFromStream(resource, stream);
+            setting = Settings.settingsBuilder().loadFromStream(resource, stream);
         } catch (IOException ex) {
             LOG.error(ex.getMessage(), ex);
             return;

--- a/janmayen/pom.xml
+++ b/janmayen/pom.xml
@@ -84,7 +84,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
+            <artifactId>slf4j-nop</artifactId>
             <scope>test</scope>
         </dependency>
         

--- a/janmayen/pom.xml
+++ b/janmayen/pom.xml
@@ -87,6 +87,35 @@
             <artifactId>slf4j-nop</artifactId>
             <scope>test</scope>
         </dependency>
-        
     </dependencies>
+    <profiles>
+        <profile>
+            <id>since-jdk9</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <dependencies>
+                            <dependency>
+                                <groupId>javax.annotation</groupId>
+                                <artifactId>javax.annotation-api</artifactId>
+                                <version>${version.javax-annotation-api}</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+            </build>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/janmayen/src/main/java/org/n52/janmayen/ClassHelper.java
+++ b/janmayen/src/main/java/org/n52/janmayen/ClassHelper.java
@@ -29,7 +29,7 @@ public final class ClassHelper {
      *
      * @param superClass the super class
      * @param clazz the class
-     * @return 0 for equality, -1 for non-hierarchy classes, >0 the lower the
+     * @return 0 for equality, -1 for non-hierarchy classes, &gt;0 the lower the
      *         more similiar
      */
     public static int getSimiliarity(Class<?> superClass, Class<?> clazz) {

--- a/janmayen/src/main/java/org/n52/janmayen/Classes.java
+++ b/janmayen/src/main/java/org/n52/janmayen/Classes.java
@@ -34,7 +34,7 @@ public class Classes {
      * @param superClass the super class
      * @param clazz      the class
      *
-     * @return 0 for equality, -1 for non-hierarchy classes, >0 the lower the more similiar
+     * @return 0 for equality, -1 for non-hierarchy classes, &gt;0 the lower the more similiar
      *
      * @see Similar
      */

--- a/janmayen/src/main/java/org/n52/janmayen/Json.java
+++ b/janmayen/src/main/java/org/n52/janmayen/Json.java
@@ -54,9 +54,9 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  * @since 1.0.0
  */
 public class Json {
-    private static final JsonNodeFactory FACTORY = JsonNodeFactory.withExactBigDecimals(false);
-    private static final ObjectReader READER;
-    private static final ObjectWriter WRITER;
+    private static JsonNodeFactory FACTORY = JsonNodeFactory.withExactBigDecimals(false);
+    private static ObjectReader READER;
+    private static ObjectWriter WRITER;
 
     static {
         ObjectMapper mapper = new ObjectMapper()
@@ -104,45 +104,47 @@ public class Json {
         }
     }
 
-    public static void print(final Writer writer, final JsonNode node) throws IOException {
+    public static void print(Writer writer, JsonNode node) throws IOException {
         writer().writeValue(writer, node);
     }
 
-    public static void print(final OutputStream writer, final JsonNode node) throws IOException {
+    public static void print(OutputStream writer, JsonNode node) throws IOException {
         writer().writeValue(writer, node);
     }
 
-    public static JsonNode loadURL(final URL url) throws IOException {
-        return reader().readTree(url.openStream());
-    }
-
-    public static JsonNode loadPath(final String path) throws IOException {
-        try (FileInputStream in = new FileInputStream(path)) {
-            return reader().readTree(in);
+    public static JsonNode loadURL(URL url) throws IOException {
+        try (InputStream stream = url.openStream()) {
+            return loadStream(stream);
         }
     }
 
-    public static JsonNode loadPath(final Path path) throws IOException {
+    public static JsonNode loadPath(String path) throws IOException {
+        try (InputStream in = new FileInputStream(path)) {
+            return loadStream(in);
+        }
+    }
+
+    public static JsonNode loadPath(Path path) throws IOException {
         try (InputStream in = Files.newInputStream(path)) {
-            return reader().readTree(in);
+            return loadStream(in);
         }
     }
 
-    public static JsonNode loadFile(final File file) throws IOException {
-        try (FileInputStream in = new FileInputStream(file)) {
-            return reader().readTree(in);
+    public static JsonNode loadFile(File file) throws IOException {
+        try (InputStream in = new FileInputStream(file)) {
+            return loadStream(in);
         }
     }
 
-    public static JsonNode loadStream(final InputStream in) throws IOException {
+    public static JsonNode loadStream(InputStream in) throws IOException {
         return reader().readTree(in);
     }
 
-    public static JsonNode loadReader(final Reader reader) throws IOException {
+    public static JsonNode loadReader(Reader reader) throws IOException {
         return reader().readTree(reader);
     }
 
-    public static JsonNode loadString(final String json) {
+    public static JsonNode loadString(String json) {
         try {
             return loadReader(new StringReader(json));
         } catch (IOException ex) {

--- a/janmayen/src/main/java/org/n52/janmayen/component/AbstractComponentRepository.java
+++ b/janmayen/src/main/java/org/n52/janmayen/component/AbstractComponentRepository.java
@@ -80,7 +80,7 @@ public abstract class AbstractComponentRepository<K, C extends Component<K>, F e
     protected Map<K, Set<Producer<C>>> getProviders(Collection<? extends C> components,
                                                     Collection<? extends F> factories) {
         return createProviders(factories, components)
-                .collect(groupingBy(KeyedProducer::getKey, mapping(x -> (Producer<C>)x, toSet())));
+                .collect(groupingBy(KeyedProducer::getKey, mapping(x -> (Producer<C>) x, toSet())));
     }
 
     private Stream<KeyedProducer<K, C>> createProviders(Collection<? extends F> factories,

--- a/janmayen/src/main/java/org/n52/janmayen/component/AbstractComponentRepository.java
+++ b/janmayen/src/main/java/org/n52/janmayen/component/AbstractComponentRepository.java
@@ -18,6 +18,7 @@ package org.n52.janmayen.component;
 
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toSet;
+import static java.util.stream.Collectors.mapping;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -79,7 +80,7 @@ public abstract class AbstractComponentRepository<K, C extends Component<K>, F e
     protected Map<K, Set<Producer<C>>> getProviders(Collection<? extends C> components,
                                                     Collection<? extends F> factories) {
         return createProviders(factories, components)
-                .collect(groupingBy(KeyedProducer::getKey, toSet()));
+                .collect(groupingBy(KeyedProducer::getKey, mapping(x -> (Producer<C>)x, toSet())));
     }
 
     private Stream<KeyedProducer<K, C>> createProviders(Collection<? extends F> factories,

--- a/pom.xml
+++ b/pom.xml
@@ -894,9 +894,6 @@
                 <inherited>false</inherited>
                 <configuration>
                     <noticeTemplate>etc/notice-template.txt</noticeTemplate>
-                    <licenseMapping>
-                        <param>http://52north.github.io/cdn/licenses/license-mappings.xml</param>
-                    </licenseMapping>
                 </configuration>
                 <executions>
                     <execution>
@@ -911,6 +908,44 @@
         </plugins>
     </build>
     <profiles>
+        <profile>
+            <id>jdk8</id>
+            <activation>
+                <jdk>1.8</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jasig.maven</groupId>
+                        <artifactId>maven-notice-plugin</artifactId>
+                        <configuration>
+                            <licenseMapping>
+                                <param>http://52north.github.io/cdn/licenses/license-mappings.xml</param>
+                            </licenseMapping>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>since-jdk9</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jasig.maven</groupId>
+                        <artifactId>maven-notice-plugin</artifactId>
+                        <configuration>
+                            <licenseMapping>
+                                <param>http://52north.github.io/cdn/licenses/license-mappings-jdk9.xml</param>
+                            </licenseMapping>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>create-license-list</id>
             <build>

--- a/pom.xml
+++ b/pom.xml
@@ -338,7 +338,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>2.12.0</version>
+                <version>2.23.0</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.hamcrest</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -300,6 +300,11 @@
                 <artifactId>jcl-over-slf4j</artifactId>
                 <version>${version.slf4j}</version>
             </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-nop</artifactId>
+                <version>${version.slf4j}</version>
+            </dependency>
             
             
             <!-- Testing --> 

--- a/pom.xml
+++ b/pom.xml
@@ -282,19 +282,13 @@
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-annotations</artifactId>
                 <version>${version.spotbugs}</version>
-            </dependency>
+            </dependency>            
 
             <!-- Guava -->
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>27.0-jre</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.google.code.findbugs</groupId>
-                        <artifactId>jsr305</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             
             

--- a/pom.xml
+++ b/pom.xml
@@ -288,7 +288,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>23.6.1-jre</version>
+                <version>27.0-jre</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.google.code.findbugs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,8 @@
         <version.olingo>4.5.0</version.olingo>
         <version.findbugs>3.0.2</version.findbugs>
         <version.spotbugs>3.1.8</version.spotbugs>
+        <version.javax-annotation-api>1.3.2</version.javax-annotation-api>            
+        <version.javax-xml-soap>1.4.0</version.javax-xml-soap>
     </properties>
     
     <dependencyManagement>
@@ -244,6 +246,16 @@
                 <groupId>javax.inject</groupId>
                 <artifactId>javax.inject</artifactId>
                 <version>1</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.annotation</groupId>
+                <artifactId>javax.annotation-api</artifactId>
+                <version>${version.javax-annotation-api}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.xml.soap</groupId>
+                <artifactId>javax.xml.soap-api</artifactId>
+                <version>${version.javax-xml-soap}</version>
             </dependency>
             
             <!-- Findbugs -->

--- a/pom.xml
+++ b/pom.xml
@@ -116,8 +116,22 @@
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
-        </repository>
+        </repository>        
     </repositories>
+    
+    <pluginRepositories>
+        <pluginRepository>
+            <id>sonatype-nexus-snapshots</id>
+            <name>Sonatype Nexus Snaphots</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
     
     <properties>
         <timestamp>${maven.build.timestamp}</timestamp>

--- a/pom.xml
+++ b/pom.xml
@@ -885,11 +885,6 @@
                     <licenseMapping>
                         <param>http://52north.github.io/cdn/licenses/license-mappings.xml</param>
                     </licenseMapping>
-                    <generateChildNotices>false</generateChildNotices>
-                    <excludeScopes>
-                        <excludeScopes>test</excludeScopes>
-                        <excludeScopes>provided</excludeScopes>
-                    </excludeScopes>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -828,8 +828,8 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.groovy.maven</groupId>
-                <artifactId>gmaven-plugin</artifactId>
+                <groupId>org.codehaus.gmaven</groupId>
+                <artifactId>groovy-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <phase>initialize</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.n52</groupId>
         <artifactId>parent</artifactId>
-        <version>12</version>
+        <version>13-SNAPSHOT</version>
     </parent>
 
     <groupId>org.n52.arctic-sea</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -123,13 +123,13 @@
         <timestamp>${maven.build.timestamp}</timestamp>
         <version.spring>4.3.20.RELEASE</version.spring>
         <version.slf4j>1.7.25</version.slf4j>
-        <version.jackson>2.9.5</version.jackson>
+        <version.jackson>2.9.7</version.jackson>
         <version.xmlbeans>3.0.1</version.xmlbeans>
-        <version.exificient>1.0.0</version.exificient>
+        <version.exificient>1.0.1</version.exificient>
         <version.n52CommonXML>2.5.0</version.n52CommonXML>
         <version.olingo>4.5.0</version.olingo>
-        <version.findbugs>3.0.1</version.findbugs>
-        <version.spotbugs>3.1.6</version.spotbugs>
+        <version.findbugs>3.0.2</version.findbugs>
+        <version.spotbugs>3.1.8</version.spotbugs>
     </properties>
     
     <dependencyManagement>
@@ -262,7 +262,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>23.4-jre</version>
+                <version>23.6.1-jre</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.google.code.findbugs</groupId>
@@ -362,12 +362,12 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpcore</artifactId>
-                <version>4.4.8</version>
+                <version>4.4.10</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.5.3</version>
+                <version>4.5.6</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.httpcomponents</groupId>
@@ -471,7 +471,7 @@
             <dependency>
                 <groupId>net.sf.saxon</groupId>
                 <artifactId>Saxon-HE</artifactId>
-                <version>9.8.0-6</version>
+                <version>9.9.0-1</version>
             </dependency>
             
 
@@ -506,7 +506,7 @@
             <dependency>
                 <groupId>com.maxmind.geoip2</groupId>
                 <artifactId>geoip2</artifactId>
-                <version>2.10.0</version>
+                <version>2.12.0</version>
                 <exclusions>
                     <exclusion>
                         <groupId>commons-logging</groupId>

--- a/shetland/pom.xml
+++ b/shetland/pom.xml
@@ -121,4 +121,34 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+    <profiles>
+        <profile>
+            <id>since-jdk9</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <dependencies>
+                            <dependency>
+                                <groupId>javax.xml.soap</groupId>
+                                <artifactId>javax.xml.soap-api</artifactId>
+                                <version>${version.javax-xml-soap}</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+            </build>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.xml.soap</groupId>
+                    <artifactId>javax.xml.soap-api</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/shetland/src/main/java/org/n52/shetland/aqd/EReportingChange.java
+++ b/shetland/src/main/java/org/n52/shetland/aqd/EReportingChange.java
@@ -16,15 +16,20 @@
  */
 package org.n52.shetland.aqd;
 
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import com.google.common.base.Optional;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class EReportingChange {
     private boolean changed;
     private Optional<String> description;
 
-    public EReportingChange(String description) {
+    public EReportingChange(@Nullable String description) {
         this(true, description);
     }
 
@@ -36,7 +41,8 @@ public class EReportingChange {
         this(changed, null);
     }
 
-    public EReportingChange(boolean changed, String description) {
+    @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
+    public EReportingChange(boolean changed, @Nullable String description) {
         this.changed = changed;
         this.description = Optional.fromNullable(description);
     }
@@ -49,7 +55,8 @@ public class EReportingChange {
         return description;
     }
 
-    public void setDescription(String description) {
+    @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
+    public void setDescription(@Nullable String description) {
         this.description = Optional.fromNullable(description);
     }
 
@@ -60,9 +67,8 @@ public class EReportingChange {
 
     @Override
     public boolean equals(Object obj) {
-        return obj instanceof EReportingChange && Objects
-               .equal(getDescription(), ((EReportingChange) obj)
-                      .getDescription());
+        return obj instanceof EReportingChange &&
+               java.util.Objects.equals(getDescription(), ((EReportingChange) obj).getDescription());
     }
 
     @Override

--- a/shetland/src/main/java/org/n52/shetland/ogc/UoM.java
+++ b/shetland/src/main/java/org/n52/shetland/ogc/UoM.java
@@ -23,9 +23,7 @@ import com.google.common.base.Strings;
 public class UoM {
 
     private String uom;
-
     private String name;
-
     private String link;
 
     public UoM(String uom) {
@@ -40,9 +38,9 @@ public class UoM {
     }
 
     /**
-     * @param uom
-     *            the uom to set
-     * @return
+     * @param uom the uom to set
+     *
+     * @return {@code this}
      */
     public UoM setUom(String uom) {
         this.uom = uom;
@@ -57,9 +55,9 @@ public class UoM {
     }
 
     /**
-     * @param name
-     *            the name to set
-     * @return
+     * @param name the name to set
+     *
+     * @return {@code this}
      */
     public UoM setName(String name) {
         this.name = name;
@@ -78,9 +76,9 @@ public class UoM {
     }
 
     /**
-     * @param link
-     *            the link to set
-     * @return
+     * @param link the link to set
+     *
+     * @return {@code this}
      */
     public UoM setLink(String link) {
         this.link = link;

--- a/shetland/src/main/java/org/n52/shetland/ogc/om/NamedValue.java
+++ b/shetland/src/main/java/org/n52/shetland/ogc/om/NamedValue.java
@@ -22,7 +22,7 @@ import org.n52.shetland.ogc.gml.ReferenceType;
 import org.n52.shetland.ogc.om.values.Value;
 
 /**
- * Class representing a O&M conform NamedValue
+ * Class representing a O&amp;M conform NamedValue
  *
  * @since 1.0.0
  *

--- a/shetland/src/main/java/org/n52/shetland/ogc/om/OmConstants.java
+++ b/shetland/src/main/java/org/n52/shetland/ogc/om/OmConstants.java
@@ -27,9 +27,9 @@ import org.n52.shetland.w3c.SchemaLocation;
 import com.google.common.collect.ImmutableSet;
 
 /**
- * Class contains element names and namespaces used to encode the O&M responses.
+ * Class contains element names and namespaces used to encode the O&amp;M responses.
  *
- * Interface contains element names and namespaces used to encode the OGC O&M
+ * Interface contains element names and namespaces used to encode the OGC O&amp;M
  * responses.
  *
  * @since 1.0.0

--- a/shetland/src/main/java/org/n52/shetland/ogc/om/OmObservation.java
+++ b/shetland/src/main/java/org/n52/shetland/ogc/om/OmObservation.java
@@ -42,7 +42,7 @@ import com.google.common.collect.Sets;
 import org.locationtech.jts.geom.Geometry;
 
 /**
- * Class represents a SOS/O&M observation
+ * Class represents a SOS/O&amp;M observation
  *
  * @since 1.0.0
  */

--- a/shetland/src/main/java/org/n52/shetland/ogc/om/OmObservationContext.java
+++ b/shetland/src/main/java/org/n52/shetland/ogc/om/OmObservationContext.java
@@ -22,7 +22,7 @@ import org.n52.shetland.ogc.gml.ReferenceType;
 
 
 /**
- * Representation of OGC O&M 2.0 ObservationContext
+ * Representation of OGC O&amp;M 2.0 ObservationContext
  *
  * @author <a href="mailto:c.hollmann@52north.org">Carsten Hollmann</a>
  * @since 1.0.0

--- a/shetland/src/main/java/org/n52/shetland/ogc/om/series/AbstractDefaultTVPMeasurementMetadata.java
+++ b/shetland/src/main/java/org/n52/shetland/ogc/om/series/AbstractDefaultTVPMeasurementMetadata.java
@@ -18,7 +18,7 @@ package org.n52.shetland.ogc.om.series;
 
 /**
  * This class implements the OGC TimeseriesML 1.0 and OGC WaterML 2.0 element
- * <code>MeasurementTimeseries > defaultPointMetadata > DefaultTVPMeasurementMetadata</code>.
+ * <code>MeasurementTimeseries &gt; defaultPointMetadata &gt; DefaultTVPMeasurementMetadata</code>.
  *
  * See <code>/req/xsd-measurement-timeseries-tvp/</code>.
  *

--- a/shetland/src/main/java/org/n52/shetland/ogc/om/series/DefaultPointMetadata.java
+++ b/shetland/src/main/java/org/n52/shetland/ogc/om/series/DefaultPointMetadata.java
@@ -18,7 +18,7 @@ package org.n52.shetland.ogc.om.series;
 
 /**
  * This class implements the OGC WaterML 2.0 and OGC TimeseriesML 1.0 element
- * <code>MeasurementTimeseries > defaultPointMetadata</code>. See
+ * <code>MeasurementTimeseries &gt; defaultPointMetadata</code>. See
  * <code>/req/xsd-timeseries-tvp/defaultPointMetadata</code>.
  *
  * @author <a href="mailto:e.h.juerrens@52north.org">Eike Hinderk J&uuml;rrens</a>

--- a/shetland/src/main/java/org/n52/shetland/ogc/om/series/tsml/TimeseriesMLConstants.java
+++ b/shetland/src/main/java/org/n52/shetland/ogc/om/series/tsml/TimeseriesMLConstants.java
@@ -20,6 +20,7 @@ import javax.xml.namespace.QName;
 
 import org.n52.janmayen.http.MediaType;
 import org.n52.shetland.ogc.om.series.AbstractInterpolationType;
+import org.n52.shetland.ogc.om.series.MeasurementTimeseriesMetadata;
 import org.n52.shetland.w3c.SchemaLocation;
 
 /**

--- a/shetland/src/main/java/org/n52/shetland/ogc/om/series/wml/DefaultTVPMeasurementMetadata.java
+++ b/shetland/src/main/java/org/n52/shetland/ogc/om/series/wml/DefaultTVPMeasurementMetadata.java
@@ -22,7 +22,7 @@ import org.n52.shetland.ogc.om.series.wml.WaterMLConstants.InterpolationType;
 
 /**
  * This class implements the OGC WaterML 2.0 element
- * <code>MeasurementTimeseries > defaultPointMetadata > DefaultTVPMeasurementMetadata</code>.
+ * <code>MeasurementTimeseries &gt; defaultPointMetadata &gt; DefaultTVPMeasurementMetadata</code>.
  *
  * See <code>/req/xsd-measurement-timeseries-tvp/interpolation-type</code>.
  *

--- a/shetland/src/main/java/org/n52/shetland/ogc/om/series/wml/WaterMLConstants.java
+++ b/shetland/src/main/java/org/n52/shetland/ogc/om/series/wml/WaterMLConstants.java
@@ -21,6 +21,7 @@ import javax.xml.namespace.QName;
 import org.n52.janmayen.http.MediaType;
 import org.n52.shetland.ogc.OGCConstants;
 import org.n52.shetland.ogc.om.series.AbstractInterpolationType;
+import org.n52.shetland.ogc.om.series.MeasurementTimeseriesMetadata;
 import org.n52.shetland.w3c.SchemaLocation;
 
 /**

--- a/shetland/src/main/java/org/n52/shetland/ogc/om/values/ComplexValue.java
+++ b/shetland/src/main/java/org/n52/shetland/ogc/om/values/ComplexValue.java
@@ -16,12 +16,13 @@
  */
 package org.n52.shetland.ogc.om.values;
 
+import java.util.Objects;
+
 import org.n52.shetland.ogc.UoM;
 import org.n52.shetland.ogc.om.values.visitor.ValueVisitor;
 import org.n52.shetland.ogc.swe.SweAbstractDataRecord;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 
 public class ComplexValue
         implements Value<SweAbstractDataRecord> {
@@ -78,21 +79,36 @@ public class ComplexValue
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this).add("value", this.value).add("unit", this.unit).toString();
+        return MoreObjects.toStringHelper(this)
+                .add("value", this.value)
+                .add("unit", this.unit)
+                .toString();
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(this.value, this.unit);
+        return Objects.hash(this.value, this.unit);
     }
 
     @Override
     public boolean equals(Object obj) {
-        return Objects.equal(this, obj);
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final ComplexValue other = (ComplexValue) obj;
+        return Objects.equals(this.value, other.value) &&
+               Objects.equals(this.unit, other.unit);
     }
 
     @Override
     public <X, E extends Exception> X accept(ValueVisitor<X, E> visitor) throws E {
         return visitor.visit(this);
     }
+
 }

--- a/shetland/src/main/java/org/n52/shetland/ogc/om/values/SweDataArrayValue.java
+++ b/shetland/src/main/java/org/n52/shetland/ogc/om/values/SweDataArrayValue.java
@@ -93,7 +93,7 @@ public class SweDataArrayValue
     }
 
     /**
-     * Adds the given block - a {@link List}<{@link String}> - add the end of
+     * Adds the given block - a {@link List}&lt;{@link String}&gt; - add the end of
      * the current list of blocks
      *
      * @param blockOfTokensToAddAtTheEnd

--- a/shetland/src/main/java/org/n52/shetland/ogc/ows/OwsDomainMetadata.java
+++ b/shetland/src/main/java/org/n52/shetland/ogc/ows/OwsDomainMetadata.java
@@ -20,8 +20,12 @@ import java.net.URI;
 import java.util.Objects;
 import java.util.Optional;
 
+import javax.annotation.Nullable;
+
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * TODO JavaDoc
@@ -33,16 +37,17 @@ public class OwsDomainMetadata {
     private final URI reference;
     private final String value;
 
-    public OwsDomainMetadata(URI reference, String value) {
+    @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
+    public OwsDomainMetadata(@Nullable URI reference, @Nullable String value) {
         this.reference = reference;
         this.value = Strings.emptyToNull(value);
     }
 
-    public OwsDomainMetadata(String value) {
+    public OwsDomainMetadata(@Nullable String value) {
         this(null, value);
     }
 
-    public OwsDomainMetadata(URI reference) {
+    public OwsDomainMetadata(@Nullable URI reference) {
         this(reference, null);
     }
 

--- a/shetland/src/main/java/org/n52/shetland/ogc/ows/OwsLanguageString.java
+++ b/shetland/src/main/java/org/n52/shetland/ogc/ows/OwsLanguageString.java
@@ -20,11 +20,15 @@ import java.util.Comparator;
 import java.util.Objects;
 import java.util.Optional;
 
+import javax.annotation.Nullable;
+
 import org.n52.janmayen.Optionals;
 import org.n52.janmayen.i18n.LocalizedString;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * TODO JavaDoc
@@ -39,7 +43,8 @@ public class OwsLanguageString implements Comparable<OwsLanguageString> {
     private final String lang;
     private final String value;
 
-    public OwsLanguageString(String lang, String value) {
+    @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
+    public OwsLanguageString(@Nullable String lang, String value) {
         this.lang = Strings.emptyToNull(lang);
         this.value = Objects.requireNonNull(Strings.emptyToNull(value));
     }

--- a/shetland/src/main/java/org/n52/shetland/ogc/ows/OwsValuesReference.java
+++ b/shetland/src/main/java/org/n52/shetland/ogc/ows/OwsValuesReference.java
@@ -19,7 +19,11 @@ package org.n52.shetland.ogc.ows;
 import java.net.URI;
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import com.google.common.base.Strings;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Reference to externally specified list of all the valid values and/or ranges
@@ -32,7 +36,8 @@ public class OwsValuesReference implements OwsPossibleValues {
     private final URI reference;
     private final String value;
 
-    public OwsValuesReference(URI reference, String value) {
+    @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
+    public OwsValuesReference(URI reference, @Nullable String value) {
         this.reference = Objects.requireNonNull(reference);
         this.value = Strings.nullToEmpty(value);
     }

--- a/shetland/src/main/java/org/n52/shetland/ogc/sensorML/elements/SmlCapabilities.java
+++ b/shetland/src/main/java/org/n52/shetland/ogc/sensorML/elements/SmlCapabilities.java
@@ -16,11 +16,12 @@
  */
 package org.n52.shetland.ogc.sensorML.elements;
 
+import static java.util.stream.Collectors.toList;
+
 import java.util.List;
 
-import org.n52.shetland.util.CollectionHelper;
 import org.n52.shetland.ogc.swe.DataRecord;
-import org.n52.shetland.ogc.swe.SweAbstractDataComponent;
+import org.n52.shetland.util.CollectionHelper;
 
 import com.google.common.collect.Lists;
 
@@ -31,21 +32,19 @@ import com.google.common.collect.Lists;
  */
 public class SmlCapabilities extends AbstractSmlDataComponentContainer<SmlCapabilities> {
 
-
     private List<SmlCapability> capabilities = Lists.newArrayList();
 
     /**
      * default constructor
      */
     public SmlCapabilities() {
-       super();
+        super();
     }
 
     /**
      * constructor
      *
-     * @param name
-     *            Type
+     * @param name Type
      */
     public SmlCapabilities(String name) {
         setName(name);
@@ -54,10 +53,8 @@ public class SmlCapabilities extends AbstractSmlDataComponentContainer<SmlCapabi
     /**
      * constructor
      *
-     * @param name
-     *            Type
-     * @param dataRecord
-     *            DataRecord
+     * @param name       Type
+     * @param dataRecord DataRecord
      */
     public SmlCapabilities(String name, DataRecord dataRecord) {
         super(dataRecord);
@@ -69,8 +66,7 @@ public class SmlCapabilities extends AbstractSmlDataComponentContainer<SmlCapabi
      */
     public List<SmlCapability> getCapabilities() {
         if (!hasCapabilities() && isSetAbstractDataComponents()) {
-            List<SmlCapability> caps = Lists.newArrayList();
-            for (SweAbstractDataComponent component : getAbstractDataComponents()) {
+            return getAbstractDataComponents().stream().map(component -> {
                 SmlCapability smlCapability = new SmlCapability();
                 if (component.isSetName()) {
                     smlCapability.setName(component.getName().getValue());
@@ -78,9 +74,9 @@ public class SmlCapabilities extends AbstractSmlDataComponentContainer<SmlCapabi
                     smlCapability.setName(component.getDefinition());
                 }
                 smlCapability.setAbstractDataComponent(component);
-                caps.add(smlCapability);
-            }
-            return caps;
+                return smlCapability;
+            }).collect(toList());
+
         }
         return this.capabilities;
     }
@@ -91,9 +87,10 @@ public class SmlCapabilities extends AbstractSmlDataComponentContainer<SmlCapabi
     public void setCapabilities(List<SmlCapability> capabilities) {
         if (CollectionHelper.isNotEmpty(capabilities)) {
             this.capabilities = capabilities;
-            for (SmlCapability smlCapability : capabilities) {
-                addAbstractDataComponents(smlCapability.getAbstractDataComponent());
-            }
+            capabilities.stream()
+                    .map(SmlCapability::getAbstractDataComponent)
+                    .forEach(this::addAbstractDataComponents);
+
         }
     }
 
@@ -102,9 +99,9 @@ public class SmlCapabilities extends AbstractSmlDataComponentContainer<SmlCapabi
      */
     public void addCapabilities(List<SmlCapability> capabilities) {
         this.capabilities.addAll(capabilities);
-        for (SmlCapability smlCapability : capabilities) {
-            addAbstractDataComponents(smlCapability.getAbstractDataComponent());
-        }
+        capabilities.stream()
+                    .map(SmlCapability::getAbstractDataComponent)
+                    .forEach(this::addAbstractDataComponents);
     }
 
     /**

--- a/shetland/src/main/java/org/n52/shetland/ogc/sos/ObjectWithXmlString.java
+++ b/shetland/src/main/java/org/n52/shetland/ogc/sos/ObjectWithXmlString.java
@@ -19,9 +19,13 @@ package org.n52.shetland.ogc.sos;
 import java.util.Objects;
 import java.util.Optional;
 
+import javax.annotation.Nullable;
+
 import org.n52.janmayen.Optionals;
 
 import com.google.common.base.Strings;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * TODO JavaDoc
@@ -33,15 +37,16 @@ public class ObjectWithXmlString<T> {
     private Optional<T> object;
     private Optional<String> xml;
 
-    public ObjectWithXmlString(T object) {
+    public ObjectWithXmlString(@Nullable T object) {
         this(object, null);
     }
 
-    public ObjectWithXmlString(String xml) {
+    public ObjectWithXmlString(@Nullable String xml) {
         this(null, xml);
     }
 
-    public ObjectWithXmlString(T object, String xml) {
+    @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
+    public ObjectWithXmlString(@Nullable T object, @Nullable String xml) {
         this.object = Optional.ofNullable(object);
         this.xml = Optional.ofNullable(Strings.emptyToNull(xml));
         if (!Optionals.any(this.object, this.xml)) {

--- a/shetland/src/main/java/org/n52/shetland/ogc/sos/SosInsertionCapabilities.java
+++ b/shetland/src/main/java/org/n52/shetland/ogc/sos/SosInsertionCapabilities.java
@@ -18,6 +18,7 @@ package org.n52.shetland.ogc.sos;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
@@ -112,5 +113,33 @@ public class SosInsertionCapabilities implements OwsCapabilitiesExtension, Merga
         addObservationTypes(insertionCapabilities.getObservationTypes());
         addProcedureDescriptionFormats(insertionCapabilities.getProcedureDescriptionFormats());
         addSupportedEncodings(insertionCapabilities.getSupportedEncodings());
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 3;
+        hash = 31 * hash + Objects.hashCode(this.featureOfInterestTypes);
+        hash = 31 * hash + Objects.hashCode(this.observationTypes);
+        hash = 31 * hash + Objects.hashCode(this.procedureDescriptionFormats);
+        hash = 31 * hash + Objects.hashCode(this.supportedEncodings);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final SosInsertionCapabilities other = (SosInsertionCapabilities) obj;
+        return Objects.equals(this.featureOfInterestTypes, other.featureOfInterestTypes) &&
+               Objects.equals(this.observationTypes, other.observationTypes) &&
+               Objects.equals(this.procedureDescriptionFormats, other.procedureDescriptionFormats) &&
+               Objects.equals(this.supportedEncodings, other.supportedEncodings);
     }
 }

--- a/shetland/src/main/java/org/n52/shetland/ogc/swe/SweDataArray.java
+++ b/shetland/src/main/java/org/n52/shetland/ogc/swe/SweDataArray.java
@@ -116,7 +116,7 @@ public class SweDataArray extends SweAbstractDataComponent {
     }
 
     /**
-     * Adds the given block - a {@link List}<{@link String}> - add the end of
+     * Adds the given block - a {@link List}&lt;{@link String}&gt; - add the end of
      * the current list of blocks
      *
      * @param blockOfTokensToAddAtTheEnd the blocks of tokens to add

--- a/shetland/src/main/java/org/n52/shetland/ogc/swe/SweDataStream.java
+++ b/shetland/src/main/java/org/n52/shetland/ogc/swe/SweDataStream.java
@@ -167,7 +167,7 @@ public class SweDataStream
     }
 
     /**
-     * Adds the given block - a {@link List}<{@link String}> - add the end of
+     * Adds the given block - a {@link List}&lt;{@link String}&gt; - add the end of
      * the current list of blocks
      *
      * @param blockOfTokensToAddAtTheEnd

--- a/shetland/src/main/java/org/n52/shetland/ogc/swe/simpleType/SweCount.java
+++ b/shetland/src/main/java/org/n52/shetland/ogc/swe/simpleType/SweCount.java
@@ -17,9 +17,9 @@
 package org.n52.shetland.ogc.swe.simpleType;
 
 import org.n52.shetland.ogc.swe.SweConstants.SweDataComponentType;
-import org.n52.shetland.w3c.xlink.Referenceable;
 import org.n52.shetland.ogc.swe.SweDataComponentVisitor;
 import org.n52.shetland.ogc.swe.VoidSweDataComponentVisitor;
+import org.n52.shetland.w3c.xlink.Referenceable;
 
 /**
  * @since 1.0.0
@@ -60,11 +60,11 @@ public class SweCount extends SweAbstractSimpleType<Integer> {
     }
 
     public void increaseCount() {
-        value++;
+        increaseCount(1);
     }
 
     public void increaseCount(int count) {
-        value += count;
+        this.value += count;
     }
 
     /**

--- a/shetland/src/main/java/org/n52/shetland/ogc/wps/Format.java
+++ b/shetland/src/main/java/org/n52/shetland/ogc/wps/Format.java
@@ -16,7 +16,6 @@
  */
 package org.n52.shetland.ogc.wps;
 
-
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -58,11 +57,15 @@ public class Format implements Comparable<Format> {
     private final Optional<String> schema;
 
     public Format(String mimeType) {
-        this(mimeType, (String) null, null);
+        this(Optional.ofNullable(Strings.emptyToNull(mimeType)),
+             Optional.empty(),
+             Optional.empty());
     }
 
     public Format(String mimeType, String encoding) {
-        this(mimeType, encoding, null);
+        this(Optional.ofNullable(Strings.emptyToNull(mimeType)),
+             Optional.ofNullable(Strings.emptyToNull(encoding)),
+             Optional.empty());
     }
 
     public Format(String mimeType, String encoding, String schema) {
@@ -71,22 +74,28 @@ public class Format implements Comparable<Format> {
              Optional.ofNullable(Strings.emptyToNull(schema)));
     }
 
+    public Format(String mimeType, Charset encoding) {
+        this(Optional.ofNullable(Strings.emptyToNull(mimeType)),
+             Optional.ofNullable(encoding).map(Charset::name),
+             Optional.empty());
+    }
+
+    public Format(String mimeType, Charset encoding, String schema) {
+        this(Optional.ofNullable(Strings.emptyToNull(mimeType)),
+             Optional.ofNullable(encoding).map(Charset::name),
+             Optional.ofNullable(Strings.emptyToNull(schema)));
+    }
+
+    public Format() {
+        this(Optional.empty(),
+             Optional.empty(),
+             Optional.empty());
+    }
+
     private Format(Optional<String> mimeType, Optional<String> encoding, Optional<String> schema) {
         this.mimeType = Objects.requireNonNull(mimeType);
         this.encoding = Objects.requireNonNull(encoding);
         this.schema = Objects.requireNonNull(schema);
-    }
-
-    public Format(String mimeType, Charset encoding) {
-        this(mimeType, encoding, null);
-    }
-
-    public Format(String mimeType, Charset encoding, String schema) {
-        this(mimeType, encoding == null ? null : encoding.name(), schema);
-    }
-
-    public Format() {
-        this(null, (String) null, null);
     }
 
     public Optional<String> getMimeType() {
@@ -236,8 +245,8 @@ public class Format implements Comparable<Format> {
     }
 
     public boolean isCompatible(Format that) {
-        if (!((!this.hasEncoding() && (!that.hasEncoding() || that.isCharacterEncoding()))
-                || this.hasEncoding(that))) {
+        if (!((!this.hasEncoding() && (!that.hasEncoding() || that.isCharacterEncoding())) ||
+              this.hasEncoding(that))) {
             return false;
         }
 

--- a/shetland/src/main/java/org/n52/shetland/ogc/wps/data/impl/InMemoryValueProcessData.java
+++ b/shetland/src/main/java/org/n52/shetland/ogc/wps/data/impl/InMemoryValueProcessData.java
@@ -27,6 +27,9 @@ import org.n52.shetland.ogc.wps.data.ValueProcessData;
 
 import com.google.common.base.MoreObjects;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@SuppressFBWarnings(value = "EI_EXPOSE_REP2")
 public class InMemoryValueProcessData extends ValueProcessData {
 
     private final byte[] bytes;

--- a/shetland/src/main/java/org/n52/shetland/ogc/wps/description/impl/ProcessDescriptionImpl.java
+++ b/shetland/src/main/java/org/n52/shetland/ogc/wps/description/impl/ProcessDescriptionImpl.java
@@ -136,6 +136,38 @@ public class ProcessDescriptionImpl
         return version;
     }
 
+    @Override
+    public int hashCode() {
+        int hash = 5;
+        hash = 97 * hash + Objects.hashCode(this.inputs);
+        hash = 97 * hash + Objects.hashCode(this.outputs);
+        hash = 97 * hash + (this.storeSupported ? 1 : 0);
+        hash = 97 * hash + (this.statusSupported ? 1 : 0);
+        hash = 97 * hash + Objects.hashCode(this.version);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final ProcessDescriptionImpl other = (ProcessDescriptionImpl) obj;
+
+        return this.storeSupported != other.storeSupported &&
+               this.statusSupported != other.statusSupported &&
+               Objects.equals(this.version, other.version) &&
+               Objects.equals(this.inputs, other.inputs) &&
+               Objects.equals(this.outputs, other.outputs);
+    }
+
+
     public abstract static class AbstractBuilder<T extends ProcessDescription,
                                                  B extends ProcessDescription.Builder<T, B>>
             extends AbstractDescription.AbstractBuilder<T, B>

--- a/shetland/src/main/java/org/n52/shetland/util/HTTP.java
+++ b/shetland/src/main/java/org/n52/shetland/util/HTTP.java
@@ -39,11 +39,14 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.CharStreams;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * TODO JavaDoc
  *
  * @author Christian Autermann
  */
+@SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE", justification = "spotbugs false positive")
 public final class HTTP {
     private static final CloseableHttpClient CLIENT = HttpClientBuilder.create()
             .useSystemProperties()

--- a/shetland/src/main/java/org/n52/shetland/util/StringHelper.java
+++ b/shetland/src/main/java/org/n52/shetland/util/StringHelper.java
@@ -22,6 +22,8 @@ import static java.util.stream.Collectors.toList;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -31,26 +33,29 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Stream;
 
+import javax.annotation.Nullable;
+
 import com.google.common.base.Strings;
 import com.google.common.io.CharStreams;
 
 /**
- * Helper class for String objects. Contains methods to join Strings, convert
- * streams to Strings or to check for null and emptiness.
+ * Helper class for String objects. Contains methods to join Strings, convert streams to Strings or to check for null
+ * and emptiness.
  *
  * @since 1.0.0
  *
  */
 public final class StringHelper {
+    private static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
+
     private StringHelper() {
     }
 
     /**
-     * @param toNormalize
-     *                    the string to normalize
+     * @param toNormalize the string to normalize
      *
-     * @return a normalized String for use in a file path, i.e. all
-     *         [\,/,:,*,?,",&lt;,&gt;,;] characters are replaced by '_'.
+     * @return a normalized String for use in a file path, i.e. all [\,/,:,*,?,",&lt;,&gt;,;] characters are replaced by
+     *         '_'.
      */
     public static String normalize(String toNormalize) {
         // toNormalize = toNormalize.replaceAll("ä", "ae");
@@ -66,8 +71,7 @@ public final class StringHelper {
     /**
      * Check if string is not null and not empty
      *
-     * @param string
-     *               string to check
+     * @param string string to check
      *
      * @return empty or not
      *
@@ -78,8 +82,9 @@ public final class StringHelper {
         return !Strings.isNullOrEmpty(string);
     }
 
-    public static String convertStreamToString(InputStream is, String charset) throws IOException {
-        try (InputStreamReader reader = new InputStreamReader(is, Strings.emptyToNull(charset))) {
+    public static String convertStreamToString(InputStream is, @Nullable String charset) throws IOException {
+        String cs = Optional.ofNullable(charset).map(Strings::emptyToNull).orElseGet(DEFAULT_CHARSET::name);
+        try (InputStreamReader reader = new InputStreamReader(is, cs)) {
             return CharStreams.toString(reader);
         } catch (IOException ex) {
             throw new IOException("Error while reading content of HTTP request", ex);

--- a/shetland/src/main/java/org/n52/shetland/util/StringHelper.java
+++ b/shetland/src/main/java/org/n52/shetland/util/StringHelper.java
@@ -50,7 +50,7 @@ public final class StringHelper {
      *                    the string to normalize
      *
      * @return a normalized String for use in a file path, i.e. all
-     *         [\,/,:,*,?,",<,>,;] characters are replaced by '_'.
+     *         [\,/,:,*,?,",&lt;,&gt;,;] characters are replaced by '_'.
      */
     public static String normalize(String toNormalize) {
         // toNormalize = toNormalize.replaceAll("ä", "ae");

--- a/shetland/src/main/java/org/n52/shetland/w3c/xlink/Link.java
+++ b/shetland/src/main/java/org/n52/shetland/w3c/xlink/Link.java
@@ -20,7 +20,11 @@ import java.net.URI;
 import java.util.Objects;
 import java.util.Optional;
 
+import javax.annotation.Nullable;
+
 import com.google.common.base.Strings;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * TODO JavaDoc
@@ -35,16 +39,22 @@ public class Link {
     private final Optional<Show> show;
     private final Optional<Actuate> actuate;
 
-    public Link(URI href) {
+    public Link(@Nullable URI href) {
         this(href, null, null, null, null, null);
     }
 
-    public Link(URI href, String title) {
+    public Link(@Nullable URI href,
+                @Nullable String title) {
         this(href, null, null, title, null, null);
     }
 
-    public Link(URI href, URI role, URI arcrole, String title, Show show,
-                Actuate actuate) {
+    @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
+    public Link(@Nullable URI href,
+                @Nullable URI role,
+                @Nullable URI arcrole,
+                @Nullable String title,
+                @Nullable Show show,
+                @Nullable Actuate actuate) {
         this.href = Optional.ofNullable(href);
         this.role = Optional.ofNullable(role);
         this.arcrole = Optional.ofNullable(arcrole);

--- a/svalbard/core/pom.xml
+++ b/svalbard/core/pom.xml
@@ -127,4 +127,34 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>since-jdk9</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <dependencies>
+                            <dependency>
+                                <groupId>javax.xml.soap</groupId>
+                                <artifactId>javax.xml.soap-api</artifactId>
+                                <version>${version.javax-xml-soap}</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+            </build>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.xml.soap</groupId>
+                    <artifactId>javax.xml.soap-api</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/svalbard/core/src/main/java/org/n52/svalbard/encode/ObservationEncoder.java
+++ b/svalbard/core/src/main/java/org/n52/svalbard/encode/ObservationEncoder.java
@@ -32,7 +32,7 @@ import org.n52.svalbard.ConformanceClass;
 public interface ObservationEncoder<S, T> extends ConformanceClass, Encoder<S, T> {
 
     /**
-     * Indicator whether the ObservationEncoder of type or subtype Observation&Measurement 2.0
+     * Indicator whether the ObservationEncoder of type or subtype Observation &amp; Measurement 2.0
      *
      * @return Of type or not
      */

--- a/svalbard/core/src/main/java/org/n52/svalbard/encode/UVFEncoder.java
+++ b/svalbard/core/src/main/java/org/n52/svalbard/encode/UVFEncoder.java
@@ -424,17 +424,17 @@ public class UVFEncoder implements ObservationEncoder<BinaryAttachmentResponse, 
                         .isSetGeometry()) {
             AbstractSamplingFeature sf = (AbstractSamplingFeature) f;
             // Rechtswert
-            String xString = sf.isSetGeometry() ? Double.toString(sf.getGeometry().getCoordinate().y) : "";
+            String xString = sf.isSetGeometry() ? Double.toString(sf.getGeometry().getCoordinate().getY()) : "";
             xString = ensureValueLength(xString, 10);
             sb.append(xString);
             fillWithSpaces(sb, 25);
             // Hochwert
-            String yString = sf.isSetGeometry() ? Double.toString(sf.getGeometry().getCoordinate().x) : "";
+            String yString = sf.isSetGeometry() ? Double.toString(sf.getGeometry().getCoordinate().getX()) : "";
             yString = ensureValueLength(yString, 10);
             sb.append(yString);
             fillWithSpaces(sb, 35);
-            if (sf.isSetGeometry() && !Double.isNaN(sf.getGeometry().getCoordinate().z)) {
-                String zString = Double.toString(sf.getGeometry().getCoordinate().z);
+            if (sf.isSetGeometry() && !Double.isNaN(sf.getGeometry().getCoordinate().getZ())) {
+                String zString = Double.toString(sf.getGeometry().getCoordinate().getZ());
                 zString = ensureValueLength(zString, 10);
                 sb.append(zString);
             }

--- a/svalbard/core/src/main/java/org/n52/svalbard/util/CodingHelper.java
+++ b/svalbard/core/src/main/java/org/n52/svalbard/util/CodingHelper.java
@@ -40,14 +40,14 @@ import org.n52.svalbard.encode.XmlEncoderKey;
 import org.n52.svalbard.encode.XmlPropertyTypeEncoderKey;
 
 /**
- * TODO implement encodeToXml(Object o) using a Map from o.getClass().getName()
- * -> namespaces
+ *
  *
  * @author <a href="mailto:c.autermann@52north.org">Christian Autermann</a>
  *
  * @since 1.0.0
  *
  */
+// TODO implement encodeToXml(Object o) using a Map from o.getClass().getName() -> namespaces
 public final class CodingHelper {
 
     private CodingHelper() {

--- a/svalbard/json-common/src/main/java/org/n52/svalbard/decode/json/JSONDecoder.java
+++ b/svalbard/json-common/src/main/java/org/n52/svalbard/decode/json/JSONDecoder.java
@@ -183,7 +183,7 @@ public abstract class JSONDecoder<T>
                 }
                 return ct;
             } else if (node.isTextual()) {
-                return (CodeType) new CodeType(node.textValue());
+                return new CodeType(node.textValue());
             }
         } catch (URISyntaxException e) {
             LOGGER.error("Error while creating URI!", e);

--- a/svalbard/json/src/main/java/org/n52/svalbard/encode/json/GeoJSONEncoder.java
+++ b/svalbard/json/src/main/java/org/n52/svalbard/encode/json/GeoJSONEncoder.java
@@ -162,10 +162,10 @@ public class GeoJSONEncoder
 
     protected ArrayNode encodeCoordinate(Coordinate coordinate) {
 
-        ArrayNode array = jsonFactory.arrayNode().add(coordinate.x).add(coordinate.y);
+        ArrayNode array = jsonFactory.arrayNode().add(coordinate.getX()).add(coordinate.getY());
 
-        if (!Double.isNaN(coordinate.z)) {
-            array.add(coordinate.z);
+        if (!Double.isNaN(coordinate.getZ())) {
+            array.add(coordinate.getZ());
         }
 
         return array;

--- a/svalbard/json/src/test/java/org/n52/svalbard/encode/json/EReportingHeaderJSONEncoderTest.java
+++ b/svalbard/json/src/test/java/org/n52/svalbard/encode/json/EReportingHeaderJSONEncoderTest.java
@@ -42,7 +42,7 @@ public class EReportingHeaderJSONEncoderTest extends AbstractEReportingHeaderCod
 
         JsonNode o = getEncoder().encode(header);
 
-        System.out.println(Json.print(o));
+        //System.out.println(Json.print(o));
     }
 
 }

--- a/svalbard/xmlbeans/pom.xml
+++ b/svalbard/xmlbeans/pom.xml
@@ -278,8 +278,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>1.7.25</version>
+            <artifactId>slf4j-nop</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/svalbard/xmlbeans/pom.xml
+++ b/svalbard/xmlbeans/pom.xml
@@ -224,8 +224,8 @@
             <groupId>org.n52.sensorweb</groupId>
             <artifactId>52n-xml-sosro-v10</artifactId>
         </dependency>
-                <dependency>
-        <groupId>org.n52.sensorweb</groupId>
+        <dependency>
+            <groupId>org.n52.sensorweb</groupId>
             <artifactId>52n-xml-sosrf-v10</artifactId>
         </dependency>
         <dependency>
@@ -306,4 +306,34 @@
             <artifactId>xmlunit</artifactId>
         </dependency>
     </dependencies>
+    <profiles>
+        <profile>
+            <id>since-jdk9</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <dependencies>
+                            <dependency>
+                                <groupId>javax.xml.soap</groupId>
+                                <artifactId>javax.xml.soap-api</artifactId>
+                                <version>${version.javax-xml-soap}</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+            </build>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.xml.soap</groupId>
+                    <artifactId>javax.xml.soap-api</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/svalbard/xmlbeans/src/main/java/org/n52/svalbard/encode/AbstractObservationResponseEncoder.java
+++ b/svalbard/xmlbeans/src/main/java/org/n52/svalbard/encode/AbstractObservationResponseEncoder.java
@@ -101,7 +101,7 @@ public abstract class AbstractObservationResponseEncoder<T extends AbstractObser
     }
 
     /**
-     * Create a response using the provided O&M2 compatible observation encoder.
+     * Create a response using the provided O&amp;M2 compatible observation encoder.
      *
      * @param encoder  the encoder
      * @param response the response

--- a/svalbard/xmlbeans/src/main/java/org/n52/svalbard/encode/AbstractOmEncoderv20.java
+++ b/svalbard/xmlbeans/src/main/java/org/n52/svalbard/encode/AbstractOmEncoderv20.java
@@ -122,7 +122,7 @@ public abstract class AbstractOmEncoderv20
 
     /**
      * Method to add the observation type to the om:Observation. Subclasses
-     * should have mappings to set the correct type, e.g. O&M .../Measurement ==
+     * should have mappings to set the correct type, e.g. O&amp;M .../Measurement ==
      * .../MeasurementTimeseriesTVPObservation in WaterML 2.0
      *
      * @param xbObservation
@@ -214,13 +214,13 @@ public abstract class AbstractOmEncoderv20
     }
 
     /**
-     * Method to create an O&M 2.0 observation XmlBeans object
+     * Method to create an O&amp;M 2.0 observation XmlBeans object
      *
      * @param sosObservation
      *            SosObservation to be encoded
      * @param context
      *            Additional values which are used during the encoding
-     * @return XmlBeans representation of O&M 2.0 observation
+     * @return XmlBeans representation of O&amp;M 2.0 observation
      * @throws EncodingException
      *             If an error occurs
      */

--- a/svalbard/xmlbeans/src/main/java/org/n52/svalbard/encode/TsmlTDREncoderv10.java
+++ b/svalbard/xmlbeans/src/main/java/org/n52/svalbard/encode/TsmlTDREncoderv10.java
@@ -26,7 +26,18 @@ import java.util.Set;
 
 import javax.xml.stream.XMLStreamException;
 
+import net.opengis.gml.x32.MeasureOrNilReasonListType;
+import net.opengis.gml.x32.QuantityListDocument;
+import net.opengis.om.x20.OMObservationType;
+import net.opengis.watermlDr.x20.MeasurementTimeseriesCoverageType;
+import net.opengis.watermlDr.x20.MeasurementTimeseriesDomainRangeDocument;
+import net.opengis.watermlDr.x20.TimePositionListDocument;
+import net.opengis.watermlDr.x20.TimePositionListType;
+
 import org.apache.xmlbeans.XmlObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.n52.shetland.ogc.OGCConstants;
 import org.n52.shetland.ogc.SupportedType;
 import org.n52.shetland.ogc.gml.AbstractFeature;
@@ -41,6 +52,7 @@ import org.n52.shetland.ogc.om.OmObservableProperty;
 import org.n52.shetland.ogc.om.OmObservation;
 import org.n52.shetland.ogc.om.SingleObservationValue;
 import org.n52.shetland.ogc.om.TimeValuePair;
+import org.n52.shetland.ogc.om.series.tsml.TimeseriesMLConstants;
 import org.n52.shetland.ogc.om.values.CountValue;
 import org.n52.shetland.ogc.om.values.QuantityValue;
 import org.n52.shetland.ogc.om.values.TVPValue;
@@ -57,25 +69,12 @@ import org.n52.svalbard.encode.exception.EncodingException;
 import org.n52.svalbard.encode.exception.UnsupportedEncoderInputException;
 import org.n52.svalbard.util.CodingHelper;
 import org.n52.svalbard.write.TsmlTDREncoderv10XmlStreamWriter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-
-import net.opengis.gml.x32.MeasureOrNilReasonListType;
-import net.opengis.gml.x32.QuantityListDocument;
-import net.opengis.om.x20.OMObservationType;
-
-import net.opengis.watermlDr.x20.MeasurementTimeseriesCoverageType;
-import net.opengis.watermlDr.x20.MeasurementTimeseriesDomainRangeDocument;
-import net.opengis.watermlDr.x20.TimePositionListDocument;
-import net.opengis.watermlDr.x20.TimePositionListType;
-
-import org.n52.shetland.ogc.om.series.tsml.TimeseriesMLConstants;
 
 /**
  * Encoder class for WaterML 2.0 TimeseriesDomainRange (TDR)
@@ -95,12 +94,13 @@ public class TsmlTDREncoderv10
 
     private static final Set<EncoderKey> ENCODER_KEYS = createEncoderKeys();
 
-    private static final ImmutableSet<SupportedType> SUPPORTED_TYPES = ImmutableSet.<SupportedType> builder()
+    private static final ImmutableSet<SupportedType> SUPPORTED_TYPES = ImmutableSet.<SupportedType>builder()
             .add(new ObservationType(TimeseriesMLConstants.OBSERVATION_TYPE_MEASURMENT_TDR)).build();
 
-    private static final Map<String, Map<String, Set<String>>> SUPPORTED_RESPONSE_FORMATS =
-            Collections.singletonMap(SosConstants.SOS, Collections.singletonMap(Sos2Constants.SERVICEVERSION,
-                    Collections.singleton(TimeseriesMLConstants.NS_TSML_10)));
+    private static final Map<String, Map<String, Set<String>>> SUPPORTED_RESPONSE_FORMATS = Collections
+            .singletonMap(SosConstants.SOS, Collections.singletonMap(
+                          Sos2Constants.SERVICEVERSION,
+                          Collections.singleton(TimeseriesMLConstants.NS_TSML_10)));
 
     private static final String TIMESERIES_ID_PREFIX = "timeseries_";
 
@@ -110,7 +110,7 @@ public class TsmlTDREncoderv10
 
     public TsmlTDREncoderv10() {
         LOGGER.debug("Encoder for the following keys initialized successfully: {}!",
-                Joiner.on(", ").join(ENCODER_KEYS));
+                     Joiner.on(", ").join(ENCODER_KEYS));
     }
 
     @Override
@@ -145,8 +145,8 @@ public class TsmlTDREncoderv10
 
     @Override
     public Set<String> getSupportedResponseFormats(String service, String version) {
-        if (SUPPORTED_RESPONSE_FORMATS.get(service) != null
-                && SUPPORTED_RESPONSE_FORMATS.get(service).get(version) != null) {
+        if (SUPPORTED_RESPONSE_FORMATS.get(service) != null &&
+            SUPPORTED_RESPONSE_FORMATS.get(service).get(version) != null) {
             return SUPPORTED_RESPONSE_FORMATS.get(service).get(version);
         }
         return Collections.emptySet();
@@ -155,8 +155,8 @@ public class TsmlTDREncoderv10
     @Override
     public Set<SchemaLocation> getSchemaLocations() {
         return Sets.newHashSet(TimeseriesMLConstants.TSML_10_SCHEMA_LOCATION,
-                TimeseriesMLConstants.TSML_10_DR_SCHEMA_LOCATION,
-                GmlCoverageConstants.GML_COVERAGE_10_SCHEMA_LOCATION);
+                               TimeseriesMLConstants.TSML_10_DR_SCHEMA_LOCATION,
+                               GmlCoverageConstants.GML_COVERAGE_10_SCHEMA_LOCATION);
     }
 
     @Override
@@ -180,7 +180,7 @@ public class TsmlTDREncoderv10
         if (objectToEncode instanceof OmObservation) {
             try {
                 new TsmlTDREncoderv10XmlStreamWriter(ctx.with(StreamingEncoderFlags.ENCODER, this), outputStream,
-                        (OmObservation) objectToEncode).write();
+                                                     (OmObservation) objectToEncode).write();
             } catch (XMLStreamException xmlse) {
                 throw new EncodingException("Error while writing element to stream!", xmlse);
             }
@@ -204,11 +204,11 @@ public class TsmlTDREncoderv10
     @Override
     protected void addObservationType(OMObservationType xbObservation, String observationType) {
         if (!Strings.isNullOrEmpty(observationType)) {
-            if (observationType.equals(OmConstants.OBS_TYPE_MEASUREMENT)
-                    || observationType.equals(TimeseriesMLConstants.OBSERVATION_TYPE_MEASURMENT_TDR)) {
+            if (observationType.equals(OmConstants.OBS_TYPE_MEASUREMENT) ||
+                observationType.equals(TimeseriesMLConstants.OBSERVATION_TYPE_MEASURMENT_TDR)) {
                 xbObservation.addNewType().setHref(TimeseriesMLConstants.OBSERVATION_TYPE_MEASURMENT_TDR);
-            } else if (observationType.equals(OmConstants.OBS_TYPE_CATEGORY_OBSERVATION)
-                    || observationType.equals(TimeseriesMLConstants.OBSERVATION_TYPE_CATEGORICAL_TDR)) {
+            } else if (observationType.equals(OmConstants.OBS_TYPE_CATEGORY_OBSERVATION) ||
+                       observationType.equals(TimeseriesMLConstants.OBSERVATION_TYPE_CATEGORICAL_TDR)) {
                 xbObservation.addNewType().setHref(TimeseriesMLConstants.OBSERVATION_TYPE_CATEGORICAL_TDR);
             }
         }
@@ -219,27 +219,27 @@ public class TsmlTDREncoderv10
     }
 
     /**
-     * Create a XML MeasurementTimeseriesDomainRange object from SOS observation
-     * for om:result
+     * Create a XML MeasurementTimeseriesDomainRange object from SOS observation for om:result
      *
-     * @param sosObservation
-     *            SOS observation
+     * @param sosObservation SOS observation
+     *
      * @return XML MeasurementTimeseriesDomainRange object for om:result
-     * @throws EncodingException
-     *             If an error occurs
+     *
+     * @throws EncodingException If an error occurs
      */
     private XmlObject createMeasurementDomainRange(OmObservation sosObservation)
             throws EncodingException {
-        if (!sosObservation.getObservationConstellation().isSetObservationType()
-                || (sosObservation.getObservationConstellation().isSetObservationType() && isInvalidObservationType(
-                        sosObservation.getObservationConstellation().getObservationType()))) {
+        if (!sosObservation.getObservationConstellation().isSetObservationType() ||
+            (sosObservation.getObservationConstellation().isSetObservationType() && isInvalidObservationType(
+             sosObservation.getObservationConstellation().getObservationType()))) {
             throw new UnsupportedEncoderInputException(this,
-                    sosObservation.getObservationConstellation().isSetObservationType());
+                                                       sosObservation.getObservationConstellation()
+                                                               .isSetObservationType());
         }
-        MeasurementTimeseriesDomainRangeDocument xbMearuementTimeseriesDomainRangeDoc =
-                MeasurementTimeseriesDomainRangeDocument.Factory.newInstance();
-        MeasurementTimeseriesCoverageType xbMeasurementTimeseriesDomainRange =
-                xbMearuementTimeseriesDomainRangeDoc.addNewMeasurementTimeseriesDomainRange();
+        MeasurementTimeseriesDomainRangeDocument xbMearuementTimeseriesDomainRangeDoc
+                = MeasurementTimeseriesDomainRangeDocument.Factory.newInstance();
+        MeasurementTimeseriesCoverageType xbMeasurementTimeseriesDomainRange = xbMearuementTimeseriesDomainRangeDoc
+                .addNewMeasurementTimeseriesDomainRange();
         xbMeasurementTimeseriesDomainRange.setId(TIMESERIES_ID_PREFIX + sosObservation.getObservationID());
 
         // set time position list
@@ -254,20 +254,19 @@ public class TsmlTDREncoderv10
             MultiObservationValues<?> observationValue = (MultiObservationValues<?>) sosObservation.getValue();
             TVPValue tvpValue = (TVPValue) observationValue.getValue();
             List<TimeValuePair> timeValuePairs = tvpValue.getValue();
-            if (Strings.isNullOrEmpty(unit) && CollectionHelper.isNotEmpty(timeValuePairs)
-                    && timeValuePairs.get(0).getValue().isSetUnit()) {
+            if (CollectionHelper.isNotEmpty(timeValuePairs) && timeValuePairs.get(0).getValue().isSetUnit()) {
                 unit = timeValuePairs.get(0).getValue().getUnit();
             }
             quantityList.setListValue(getValueList(timeValuePairs));
         }
 
-        if (Strings.isNullOrEmpty(unit)) {
+        if (unit == null || unit.isEmpty()) {
             unit = OGCConstants.UNKNOWN;
         }
         quantityList.setUom(unit);
         // set unit to SosObservableProperty if not set.
-        if (observableProperty instanceof OmObservableProperty
-                && !((OmObservableProperty) observableProperty).isSetUnit()) {
+        if (observableProperty instanceof OmObservableProperty &&
+            !((OmObservableProperty) observableProperty).isSetUnit()) {
             ((OmObservableProperty) observableProperty).setUnit(unit);
         }
         // set up range set
@@ -281,15 +280,15 @@ public class TsmlTDREncoderv10
 
     private XmlObject createMeasurementDomainRange(AbstractObservationValue<?> observationValue)
             throws EncodingException {
-        if (!observationValue.isSetObservationType() || (observationValue.isSetObservationType()
-                && isInvalidObservationType(observationValue.getObservationType()))) {
+        if (!observationValue.isSetObservationType() ||
+            isInvalidObservationType(observationValue.getObservationType())) {
             return null;
         }
 
-        MeasurementTimeseriesDomainRangeDocument xbMearuementTimeseriesDomainRangeDoc =
-                MeasurementTimeseriesDomainRangeDocument.Factory.newInstance();
-        MeasurementTimeseriesCoverageType xbMeasurementTimeseriesDomainRange =
-                xbMearuementTimeseriesDomainRangeDoc.addNewMeasurementTimeseriesDomainRange();
+        MeasurementTimeseriesDomainRangeDocument xbMearuementTimeseriesDomainRangeDoc
+                = MeasurementTimeseriesDomainRangeDocument.Factory.newInstance();
+        MeasurementTimeseriesCoverageType xbMeasurementTimeseriesDomainRange = xbMearuementTimeseriesDomainRangeDoc
+                .addNewMeasurementTimeseriesDomainRange();
         xbMeasurementTimeseriesDomainRange.setId(TIMESERIES_ID_PREFIX + observationValue.getObservationID());
 
         // set time position list
@@ -304,14 +303,13 @@ public class TsmlTDREncoderv10
         if (observationValue instanceof MultiObservationValues) {
             TVPValue tvpValue = (TVPValue) ((MultiObservationValues<?>) observationValue).getValue();
             List<TimeValuePair> timeValuePairs = tvpValue.getValue();
-            if (Strings.isNullOrEmpty(unit) && CollectionHelper.isNotEmpty(timeValuePairs)
-                    && timeValuePairs.get(0).getValue().isSetUnit()) {
+            if (CollectionHelper.isNotEmpty(timeValuePairs) && timeValuePairs.get(0).getValue().isSetUnit()) {
                 unit = timeValuePairs.get(0).getValue().getUnit();
             }
             quantityList.setListValue(getValueList(timeValuePairs));
         }
 
-        if (Strings.isNullOrEmpty(unit)) {
+        if (unit == null || unit.isEmpty()) {
             unit = OGCConstants.UNKNOWN;
         }
         quantityList.setUom(unit);
@@ -330,14 +328,13 @@ public class TsmlTDREncoderv10
     }
 
     /**
-     * Create a SOS DataRecord object from SOS observation and encode to
-     * XmlBeans object
+     * Create a SOS DataRecord object from SOS observation and encode to XmlBeans object
      *
-     * @param sosObservation
-     *            SOS observation
+     * @param sosObservation SOS observation
+     *
      * @return XML DataRecord object
-     * @throws EncodingException
-     *             If an error occurs
+     *
+     * @throws EncodingException If an error occurs
      */
     private XmlObject createDataRecord(OmObservation sosObservation)
             throws EncodingException {
@@ -345,8 +342,8 @@ public class TsmlTDREncoderv10
         SweQuantity quantity = new SweQuantity();
         quantity.setDefinition(observableProperty.getIdentifier());
         quantity.setDescription(observableProperty.getDescription());
-        if (observableProperty instanceof OmObservableProperty
-                && ((OmObservableProperty) observableProperty).isSetUnit()) {
+        if (observableProperty instanceof OmObservableProperty &&
+            ((OmObservableProperty) observableProperty).isSetUnit()) {
             quantity.setUom(((OmObservableProperty) observableProperty).getUnit());
         }
         return createDataRecord(quantity, sosObservation.getObservationID());
@@ -369,17 +366,17 @@ public class TsmlTDREncoderv10
         dataRecord.setIdentifier(DATA_RECORD_ID_PREFIX + observationId);
         dataRecord.addField(field);
         return encodeObjectToXml(SweConstants.NS_SWE_20, dataRecord,
-                EncodingContext.of(XmlBeansEncodingFlags.FOR_OBSERVATION));
+                                 EncodingContext.of(XmlBeansEncodingFlags.FOR_OBSERVATION));
     }
 
     /**
      * Create a TimePositionList XML object from time values
      *
-     * @param sosObservation
-     *            SOS observation
+     * @param sosObservation SOS observation
+     *
      * @return XML TimePositionList object
-     * @throws EncodingException
-     *             If an error occurs
+     *
+     * @throws EncodingException If an error occurs
      */
     private TimePositionListDocument getTimePositionList(OmObservation sosObservation)
             throws EncodingException {
@@ -407,11 +404,11 @@ public class TsmlTDREncoderv10
     /**
      * Create a array from time values
      *
-     * @param sosObservationValues
-     *            SOS multi value observation object
+     * @param sosObservationValues SOS multi value observation object
+     *
      * @return List with string representations of time values
-     * @throws EncodingException
-     *             If an error occurs
+     *
+     * @throws EncodingException If an error occurs
      */
     private List<String> getTimeArray(MultiObservationValues<?> sosObservationValues)
             throws EncodingException {
@@ -422,11 +419,11 @@ public class TsmlTDREncoderv10
     /**
      * Get a value list from SOS TimeValuePair objects
      *
-     * @param timeValuePairs
-     *            SOS TimeValuePair objects
+     * @param timeValuePairs SOS TimeValuePair objects
+     *
      * @return List with value objects
-     * @throws EncodingException
-     *             If an error occurs
+     *
+     * @throws EncodingException If an error occurs
      */
     private List<Object> getValueList(List<TimeValuePair> timeValuePairs)
             throws EncodingException {
@@ -440,15 +437,19 @@ public class TsmlTDREncoderv10
     }
 
     private boolean isInvalidObservationType(String observationType) {
-        return !(OmConstants.OBS_TYPE_COUNT_OBSERVATION.equals(observationType)
-                || OmConstants.OBS_TYPE_MEASUREMENT.equals(observationType)
-                || OmConstants.OBS_TYPE_SWE_ARRAY_OBSERVATION.equals(observationType));
+        return !(OmConstants.OBS_TYPE_COUNT_OBSERVATION.equals(observationType) ||
+                 OmConstants.OBS_TYPE_MEASUREMENT.equals(observationType) ||
+                 OmConstants.OBS_TYPE_SWE_ARRAY_OBSERVATION.equals(observationType));
     }
 
     private static Set<EncoderKey> createEncoderKeys() {
-        return CollectionHelper.union(getDefaultEncoderKeys(),
-                CodingHelper.encoderKeysForElements(TimeseriesMLConstants.NS_TSML_10, GetObservationResponse.class,
-                        OmObservation.class, AbstractFeature.class, SingleObservationValue.class,
-                        MultiObservationValues.class));
+        return CollectionHelper.union(
+                getDefaultEncoderKeys(),
+                CodingHelper.encoderKeysForElements(TimeseriesMLConstants.NS_TSML_10,
+                                                    GetObservationResponse.class,
+                                                    OmObservation.class,
+                                                    AbstractFeature.class,
+                                                    SingleObservationValue.class,
+                                                    MultiObservationValues.class));
     }
 }

--- a/svalbard/xmlbeans/src/main/java/org/n52/svalbard/encode/TsmlTVPEncoderv10.java
+++ b/svalbard/xmlbeans/src/main/java/org/n52/svalbard/encode/TsmlTVPEncoderv10.java
@@ -25,6 +25,16 @@ import java.util.function.Supplier;
 
 import javax.xml.stream.XMLStreamException;
 
+import net.opengis.gml.x32.AbstractGMLType;
+import net.opengis.om.x20.OMObservationType;
+import net.opengis.tsml.x10.MeasurementTVPPropertyType;
+import net.opengis.tsml.x10.MeasurementTVPType;
+import net.opengis.tsml.x10.PointMetadataDocument;
+import net.opengis.tsml.x10.PointMetadataType;
+import net.opengis.tsml.x10.TimeseriesMetadataType;
+import net.opengis.tsml.x10.TimeseriesTVPDocument;
+import net.opengis.tsml.x10.TimeseriesTVPType;
+
 import org.apache.xmlbeans.XmlObject;
 import org.apache.xmlbeans.XmlOptions;
 import org.slf4j.Logger;
@@ -66,17 +76,6 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
-import net.opengis.gml.x32.AbstractGMLType;
-
-import net.opengis.om.x20.OMObservationType;
-
-import net.opengis.tsml.x10.MeasurementTVPPropertyType;
-import net.opengis.tsml.x10.MeasurementTVPType;
-import net.opengis.tsml.x10.PointMetadataDocument;
-import net.opengis.tsml.x10.PointMetadataType;
-import net.opengis.tsml.x10.TimeseriesMetadataType;
-import net.opengis.tsml.x10.TimeseriesTVPDocument;
-import net.opengis.tsml.x10.TimeseriesTVPType;
 
 /**
  * Encoder class for TimeseriesML 1.0 TimeseriesValuePair (TVP)
@@ -421,7 +420,7 @@ public class TsmlTVPEncoderv10
         MeasurementTVPPropertyType measurementTVPProperty = MeasurementTVPPropertyType.Factory.newInstance();
 
         measurementTVP.addNewTime().setStringValue(time);
-        if (Strings.isNullOrEmpty(value)) {
+        if (value == null || value.isEmpty()) {
             measurementTVP.addNewValue().setNil();
             measurementTVP.addNewMetadata().addNewPointMetadata().addNewNilReason().setNilReason("missing");
         } else {

--- a/svalbard/xmlbeans/src/main/java/org/n52/svalbard/encode/WmlTDREncoderv20.java
+++ b/svalbard/xmlbeans/src/main/java/org/n52/svalbard/encode/WmlTDREncoderv20.java
@@ -26,7 +26,18 @@ import java.util.Set;
 
 import javax.xml.stream.XMLStreamException;
 
+import net.opengis.gml.x32.MeasureOrNilReasonListType;
+import net.opengis.gml.x32.QuantityListDocument;
+import net.opengis.om.x20.OMObservationType;
+import net.opengis.watermlDr.x20.MeasurementTimeseriesCoverageType;
+import net.opengis.watermlDr.x20.MeasurementTimeseriesDomainRangeDocument;
+import net.opengis.watermlDr.x20.TimePositionListDocument;
+import net.opengis.watermlDr.x20.TimePositionListType;
+
 import org.apache.xmlbeans.XmlObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.n52.shetland.ogc.OGCConstants;
 import org.n52.shetland.ogc.SupportedType;
 import org.n52.shetland.ogc.gml.AbstractFeature;
@@ -58,22 +69,11 @@ import org.n52.svalbard.encode.exception.EncodingException;
 import org.n52.svalbard.encode.exception.UnsupportedEncoderInputException;
 import org.n52.svalbard.util.CodingHelper;
 import org.n52.svalbard.write.WmlTDREncoderv20XmlStreamWriter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-
-import net.opengis.gml.x32.MeasureOrNilReasonListType;
-import net.opengis.gml.x32.QuantityListDocument;
-import net.opengis.om.x20.OMObservationType;
-import net.opengis.watermlDr.x20.MeasurementTimeseriesCoverageType;
-import net.opengis.watermlDr.x20.MeasurementTimeseriesDomainRangeDocument;
-import net.opengis.watermlDr.x20.TimePositionListDocument;
-import net.opengis.watermlDr.x20.TimePositionListType;
 
 /**
  * Encoder class for WaterML 2.0 TimeseriesDomainRange (TDR)
@@ -92,12 +92,12 @@ public class WmlTDREncoderv20
 
     private static final Set<EncoderKey> ENCODER_KEYS = createEncoderKeys();
 
-    private static final ImmutableSet<SupportedType> SUPPORTED_TYPES = ImmutableSet.<SupportedType> builder()
+    private static final ImmutableSet<SupportedType> SUPPORTED_TYPES = ImmutableSet.<SupportedType>builder()
             .add(new ObservationType(WaterMLConstants.OBSERVATION_TYPE_MEASURMENT_TDR)).build();
 
-    private static final Map<String, Map<String, Set<String>>> SUPPORTED_RESPONSE_FORMATS =
-            Collections.singletonMap(SosConstants.SOS, Collections.singletonMap(Sos2Constants.SERVICEVERSION,
-                    Collections.singleton(WaterMLConstants.NS_WML_20_DR)));
+    private static final Map<String, Map<String, Set<String>>> SUPPORTED_RESPONSE_FORMATS = Collections
+            .singletonMap(SosConstants.SOS, Collections.singletonMap(
+                          Sos2Constants.SERVICEVERSION, Collections.singleton(WaterMLConstants.NS_WML_20_DR)));
 
     private static final String TIMESERIES_ID_PREFIX = "timeseries_";
 
@@ -107,7 +107,7 @@ public class WmlTDREncoderv20
 
     public WmlTDREncoderv20() {
         LOGGER.debug("Encoder for the following keys initialized successfully: {}!",
-                Joiner.on(", ").join(ENCODER_KEYS));
+                     Joiner.on(", ").join(ENCODER_KEYS));
     }
 
     @Override
@@ -142,8 +142,8 @@ public class WmlTDREncoderv20
 
     @Override
     public Set<String> getSupportedResponseFormats(String service, String version) {
-        if (SUPPORTED_RESPONSE_FORMATS.get(service) != null
-                && SUPPORTED_RESPONSE_FORMATS.get(service).get(version) != null) {
+        if (SUPPORTED_RESPONSE_FORMATS.get(service) != null &&
+            SUPPORTED_RESPONSE_FORMATS.get(service).get(version) != null) {
             return SUPPORTED_RESPONSE_FORMATS.get(service).get(version);
         }
         return Collections.emptySet();
@@ -152,7 +152,7 @@ public class WmlTDREncoderv20
     @Override
     public Set<SchemaLocation> getSchemaLocations() {
         return Sets.newHashSet(WaterMLConstants.WML_20_SCHEMA_LOCATION, WaterMLConstants.WML_20_DR_SCHEMA_LOCATION,
-                GmlCoverageConstants.GML_COVERAGE_10_SCHEMA_LOCATION);
+                               GmlCoverageConstants.GML_COVERAGE_10_SCHEMA_LOCATION);
     }
 
     @Override
@@ -175,7 +175,7 @@ public class WmlTDREncoderv20
         if (objectToEncode instanceof OmObservation) {
             try {
                 new WmlTDREncoderv20XmlStreamWriter(ctx.with(StreamingEncoderFlags.ENCODER, this), outputStream,
-                        (OmObservation) objectToEncode).write();
+                                                    (OmObservation) objectToEncode).write();
             } catch (XMLStreamException xmlse) {
                 throw new EncodingException("Error while writing element to stream!", xmlse);
             }
@@ -196,12 +196,12 @@ public class WmlTDREncoderv20
 
     @Override
     protected void addObservationType(OMObservationType xbObservation, String observationType) {
-        if (!Strings.isNullOrEmpty(observationType)) {
-            if (observationType.equals(OmConstants.OBS_TYPE_MEASUREMENT)
-                    || observationType.equals(WaterMLConstants.OBSERVATION_TYPE_MEASURMENT_TDR)) {
+        if (observationType != null && !observationType.isEmpty()) {
+            if (observationType.equals(OmConstants.OBS_TYPE_MEASUREMENT) ||
+                observationType.equals(WaterMLConstants.OBSERVATION_TYPE_MEASURMENT_TDR)) {
                 xbObservation.addNewType().setHref(WaterMLConstants.OBSERVATION_TYPE_MEASURMENT_TDR);
-            } else if (observationType.equals(OmConstants.OBS_TYPE_CATEGORY_OBSERVATION)
-                    || observationType.equals(WaterMLConstants.OBSERVATION_TYPE_CATEGORICAL_TDR)) {
+            } else if (observationType.equals(OmConstants.OBS_TYPE_CATEGORY_OBSERVATION) ||
+                       observationType.equals(WaterMLConstants.OBSERVATION_TYPE_CATEGORICAL_TDR)) {
                 xbObservation.addNewType().setHref(WaterMLConstants.OBSERVATION_TYPE_CATEGORICAL_TDR);
             }
         }
@@ -212,26 +212,26 @@ public class WmlTDREncoderv20
     }
 
     /**
-     * Create a XML MeasurementTimeseriesDomainRange object from SOS observation
-     * for om:result
+     * Create a XML MeasurementTimeseriesDomainRange object from SOS observation for om:result
      *
-     * @param sosObservation
-     *            SOS observation
+     * @param sosObservation SOS observation
+     *
      * @return XML MeasurementTimeseriesDomainRange object for om:result
-     * @throws EncodingException
-     *             If an error occurs
+     *
+     * @throws EncodingException If an error occurs
      */
     private XmlObject createMeasurementDomainRange(OmObservation sosObservation) throws EncodingException {
-        if (!sosObservation.getObservationConstellation().isSetObservationType()
-                || (sosObservation.getObservationConstellation().isSetObservationType() && isInvalidObservationType(
-                        sosObservation.getObservationConstellation().getObservationType()))) {
+        if (!sosObservation.getObservationConstellation().isSetObservationType() ||
+            (sosObservation.getObservationConstellation().isSetObservationType() && isInvalidObservationType(
+             sosObservation.getObservationConstellation().getObservationType()))) {
             throw new UnsupportedEncoderInputException(this,
-                    sosObservation.getObservationConstellation().isSetObservationType());
+                                                       sosObservation.getObservationConstellation()
+                                                               .isSetObservationType());
         }
-        MeasurementTimeseriesDomainRangeDocument xbMearuementTimeseriesDomainRangeDoc =
-                MeasurementTimeseriesDomainRangeDocument.Factory.newInstance();
-        MeasurementTimeseriesCoverageType xbMeasurementTimeseriesDomainRange =
-                xbMearuementTimeseriesDomainRangeDoc.addNewMeasurementTimeseriesDomainRange();
+        MeasurementTimeseriesDomainRangeDocument xbMearuementTimeseriesDomainRangeDoc
+                = MeasurementTimeseriesDomainRangeDocument.Factory.newInstance();
+        MeasurementTimeseriesCoverageType xbMeasurementTimeseriesDomainRange = xbMearuementTimeseriesDomainRangeDoc
+                .addNewMeasurementTimeseriesDomainRange();
         xbMeasurementTimeseriesDomainRange.setId(TIMESERIES_ID_PREFIX + sosObservation.getObservationID());
 
         // set time position list
@@ -246,20 +246,19 @@ public class WmlTDREncoderv20
             MultiObservationValues<?> observationValue = (MultiObservationValues<?>) sosObservation.getValue();
             TVPValue tvpValue = (TVPValue) observationValue.getValue();
             List<TimeValuePair> timeValuePairs = tvpValue.getValue();
-            if (Strings.isNullOrEmpty(unit) && CollectionHelper.isNotEmpty(timeValuePairs)
-                    && timeValuePairs.get(0).getValue().isSetUnit()) {
+            if (CollectionHelper.isNotEmpty(timeValuePairs) && timeValuePairs.get(0).getValue().isSetUnit()) {
                 unit = timeValuePairs.get(0).getValue().getUnit();
             }
             quantityList.setListValue(getValueList(timeValuePairs));
         }
 
-        if (Strings.isNullOrEmpty(unit)) {
+        if (unit == null || unit.isEmpty()) {
             unit = OGCConstants.UNKNOWN;
         }
         quantityList.setUom(unit);
         // set unit to SosObservableProperty if not set.
-        if (observableProperty instanceof OmObservableProperty
-                && !((OmObservableProperty) observableProperty).isSetUnit()) {
+        if (observableProperty instanceof OmObservableProperty &&
+            !((OmObservableProperty) observableProperty).isSetUnit()) {
             ((OmObservableProperty) observableProperty).setUnit(unit);
         }
         // set up range set
@@ -273,15 +272,15 @@ public class WmlTDREncoderv20
 
     private XmlObject createMeasurementDomainRange(AbstractObservationValue<?> observationValue)
             throws EncodingException {
-        if (!observationValue.isSetObservationType() || (observationValue.isSetObservationType()
-                && isInvalidObservationType(observationValue.getObservationType()))) {
+        if (!observationValue.isSetObservationType() ||
+            isInvalidObservationType(observationValue.getObservationType())) {
             return null;
         }
 
-        MeasurementTimeseriesDomainRangeDocument xbMearuementTimeseriesDomainRangeDoc =
-                MeasurementTimeseriesDomainRangeDocument.Factory.newInstance();
-        MeasurementTimeseriesCoverageType xbMeasurementTimeseriesDomainRange =
-                xbMearuementTimeseriesDomainRangeDoc.addNewMeasurementTimeseriesDomainRange();
+        MeasurementTimeseriesDomainRangeDocument xbMearuementTimeseriesDomainRangeDoc
+                = MeasurementTimeseriesDomainRangeDocument.Factory.newInstance();
+        MeasurementTimeseriesCoverageType xbMeasurementTimeseriesDomainRange = xbMearuementTimeseriesDomainRangeDoc
+                .addNewMeasurementTimeseriesDomainRange();
         xbMeasurementTimeseriesDomainRange.setId(TIMESERIES_ID_PREFIX + observationValue.getObservationID());
 
         // set time position list
@@ -296,14 +295,13 @@ public class WmlTDREncoderv20
         if (observationValue instanceof MultiObservationValues) {
             TVPValue tvpValue = (TVPValue) ((MultiObservationValues<?>) observationValue).getValue();
             List<TimeValuePair> timeValuePairs = tvpValue.getValue();
-            if (Strings.isNullOrEmpty(unit) && CollectionHelper.isNotEmpty(timeValuePairs)
-                    && timeValuePairs.get(0).getValue().isSetUnit()) {
+            if (CollectionHelper.isNotEmpty(timeValuePairs) && timeValuePairs.get(0).getValue().isSetUnit()) {
                 unit = timeValuePairs.get(0).getValue().getUnit();
             }
             quantityList.setListValue(getValueList(timeValuePairs));
         }
 
-        if (Strings.isNullOrEmpty(unit)) {
+        if (unit == null || unit.isEmpty()) {
             unit = OGCConstants.UNKNOWN;
         }
         quantityList.setUom(unit);
@@ -322,22 +320,21 @@ public class WmlTDREncoderv20
     }
 
     /**
-     * Create a SOS DataRecord object from SOS observation and encode to
-     * XmlBeans object
+     * Create a SOS DataRecord object from SOS observation and encode to XmlBeans object
      *
-     * @param sosObservation
-     *            SOS observation
+     * @param sosObservation SOS observation
+     *
      * @return XML DataRecord object
-     * @throws EncodingException
-     *             If an error occurs
+     *
+     * @throws EncodingException If an error occurs
      */
     private XmlObject createDataRecord(OmObservation sosObservation) throws EncodingException {
         AbstractPhenomenon observableProperty = sosObservation.getObservationConstellation().getObservableProperty();
         SweQuantity quantity = new SweQuantity();
         quantity.setDefinition(observableProperty.getIdentifier());
         quantity.setDescription(observableProperty.getDescription());
-        if (observableProperty instanceof OmObservableProperty
-                && ((OmObservableProperty) observableProperty).isSetUnit()) {
+        if (observableProperty instanceof OmObservableProperty &&
+            ((OmObservableProperty) observableProperty).isSetUnit()) {
             quantity.setUom(((OmObservableProperty) observableProperty).getUnit());
         }
         return createDataRecord(quantity, sosObservation.getObservationID());
@@ -359,17 +356,17 @@ public class WmlTDREncoderv20
         dataRecord.setIdentifier(DATA_RECORD_ID_PREFIX + observationId);
         dataRecord.addField(field);
         return encodeObjectToXml(SweConstants.NS_SWE_20, dataRecord,
-                EncodingContext.of(XmlBeansEncodingFlags.FOR_OBSERVATION));
+                                 EncodingContext.of(XmlBeansEncodingFlags.FOR_OBSERVATION));
     }
 
     /**
      * Create a TimePositionList XML object from time values
      *
-     * @param sosObservation
-     *            SOS observation
+     * @param sosObservation SOS observation
+     *
      * @return XML TimePositionList object
-     * @throws EncodingException
-     *             If an error occurs
+     *
+     * @throws EncodingException If an error occurs
      */
     private TimePositionListDocument getTimePositionList(OmObservation sosObservation) throws EncodingException {
         TimePositionListDocument timePositionListDoc = TimePositionListDocument.Factory.newInstance();
@@ -396,11 +393,11 @@ public class WmlTDREncoderv20
     /**
      * Create a array from time values
      *
-     * @param sosObservationValues
-     *            SOS multi value observation object
+     * @param sosObservationValues SOS multi value observation object
+     *
      * @return List with string representations of time values
-     * @throws EncodingException
-     *             If an error occurs
+     *
+     * @throws EncodingException If an error occurs
      */
     private List<String> getTimeArray(MultiObservationValues<?> sosObservationValues) throws EncodingException {
         return ((TVPValue) sosObservationValues.getValue()).getValue().stream().map(TimeValuePair::getTime)
@@ -410,11 +407,11 @@ public class WmlTDREncoderv20
     /**
      * Get a value list from SOS TimeValuePair objects
      *
-     * @param timeValuePairs
-     *            SOS TimeValuePair objects
+     * @param timeValuePairs SOS TimeValuePair objects
+     *
      * @return List with value objects
-     * @throws EncodingException
-     *             If an error occurs
+     *
+     * @throws EncodingException If an error occurs
      */
     private List<Object> getValueList(List<TimeValuePair> timeValuePairs) throws EncodingException {
         return timeValuePairs.stream().map(TimeValuePair::getValue).map(value -> {
@@ -427,15 +424,19 @@ public class WmlTDREncoderv20
     }
 
     private boolean isInvalidObservationType(String observationType) {
-        return !(OmConstants.OBS_TYPE_COUNT_OBSERVATION.equals(observationType)
-                || OmConstants.OBS_TYPE_MEASUREMENT.equals(observationType)
-                || OmConstants.OBS_TYPE_SWE_ARRAY_OBSERVATION.equals(observationType));
+        return !(OmConstants.OBS_TYPE_COUNT_OBSERVATION.equals(observationType) ||
+                 OmConstants.OBS_TYPE_MEASUREMENT.equals(observationType) ||
+                 OmConstants.OBS_TYPE_SWE_ARRAY_OBSERVATION.equals(observationType));
     }
 
     private static Set<EncoderKey> createEncoderKeys() {
-        return CollectionHelper.union(getDefaultEncoderKeys(),
-                CodingHelper.encoderKeysForElements(WaterMLConstants.NS_WML_20_DR, GetObservationResponse.class,
-                        OmObservation.class, AbstractFeature.class, SingleObservationValue.class,
-                        MultiObservationValues.class));
+        return CollectionHelper.union(
+                getDefaultEncoderKeys(),
+                CodingHelper.encoderKeysForElements(WaterMLConstants.NS_WML_20_DR,
+                                                    GetObservationResponse.class,
+                                                    OmObservation.class,
+                                                    AbstractFeature.class,
+                                                    SingleObservationValue.class,
+                                                    MultiObservationValues.class));
     }
 }

--- a/svalbard/xmlbeans/src/test/java/org/n52/svalbard/encode/AbstractMetadataTest.java
+++ b/svalbard/xmlbeans/src/test/java/org/n52/svalbard/encode/AbstractMetadataTest.java
@@ -47,7 +47,7 @@ public abstract class AbstractMetadataTest {
         assertThat(parse, instanceOf(DataArrayPropertyType.class));
         DataArrayPropertyType dad = (DataArrayPropertyType) parse;
         assertThat(dad.getDataArray1(), instanceOf(DataArrayType.class));
-        DataArrayType dat = (DataArrayType) dad.getDataArray1();
+        DataArrayType dat = dad.getDataArray1();
         assertThat(dat.getElementType().isSetAbstractDataComponent(), is (true));
         assertThat(dat.getElementType().getAbstractDataComponent(), instanceOf(DataRecordType.class));
     }

--- a/svalbard/xmlbeans/src/test/java/org/n52/svalbard/encode/GetDataAvailabilityXmlEncoderTest.java
+++ b/svalbard/xmlbeans/src/test/java/org/n52/svalbard/encode/GetDataAvailabilityXmlEncoderTest.java
@@ -82,7 +82,7 @@ public class GetDataAvailabilityXmlEncoderTest {
                                                           featureOfInterest, offering, timePeriod, count));
         XmlObject encoded = encoder.encode(response);
 
-        System.out.println(encoded.xmlText());
+        //System.out.println(encoded.xmlText());
 
         errors.checkThat(encoded.xmlText(), is(String
                          .format("<gda:GetDataAvailabilityResponse xsi:schemaLocation=\"http://www.opengis.net/sosgda/1.0 http://waterml2.org/schemas/gda/1.0/gda.xsd\" " +

--- a/svalbard/xmlbeans/src/test/java/org/n52/svalbard/encode/GetObservationResponseEncoderTest.java
+++ b/svalbard/xmlbeans/src/test/java/org/n52/svalbard/encode/GetObservationResponseEncoderTest.java
@@ -123,7 +123,7 @@ public class GetObservationResponseEncoderTest {
         assertThat(parse, instanceOf(DataArrayPropertyType.class));
         DataArrayPropertyType dad = (DataArrayPropertyType) parse;
         assertThat(dad.getDataArray1(), instanceOf(DataArrayType.class));
-        DataArrayType dat = (DataArrayType) dad.getDataArray1();
+        DataArrayType dat = dad.getDataArray1();
         assertThat(dat.getElementType().isSetAbstractDataComponent(), is (true));
         assertThat(dat.getElementType().getAbstractDataComponent(), instanceOf(DataRecordType.class));
     }

--- a/svalbard/xmlbeans/src/test/java/org/n52/svalbard/encode/OmEncoderv20Test.java
+++ b/svalbard/xmlbeans/src/test/java/org/n52/svalbard/encode/OmEncoderv20Test.java
@@ -156,7 +156,7 @@ public class OmEncoderv20Test {
         XmlObject xb = omEncoderv20.encode(observation, EncodingContext.of(XmlBeansEncodingFlags.DOCUMENT));
         Node node = xb.getDomNode();
         Checker checker = new Checker(new NamespaceContextImpl());
-        System.out.println(xb.xmlText());
+        //System.out.println(xb.xmlText());
         errors.checkThat(node, checker.hasXPath("/om:OM_Observation/om:observedProperty[@xlink:href='http://example.tld/phenomenon/parent']"));
         errors.checkThat(node, checker.hasXPath("/om:OM_Observation/om:result/@xsi:type", containsString("DataRecordPropertyType")));
         errors.checkThat(node, checker.hasXPath("/om:OM_Observation/om:result/swe:DataRecord/swe:field[@name='child1']/swe:Quantity[@definition='http://example.tld/phenomenon/child/1']"));

--- a/svalbard/xmlbeans/src/test/java/org/n52/svalbard/encode/TrajectoryObservationTypeEncoderTest.java
+++ b/svalbard/xmlbeans/src/test/java/org/n52/svalbard/encode/TrajectoryObservationTypeEncoderTest.java
@@ -128,7 +128,7 @@ public class TrajectoryObservationTypeEncoderTest extends AbtractProcessDecoding
     public void test_multi_quantity() throws EncodingException, ParseException, DecodingException, XmlException, IOException {
         XmlObject encoded = encoder.encode(getQuantityObservation());
         assertThat(XmlHelper.validateDocument(encoded), is(TRUE));
-        System.out.println(encoded.xmlText(encoder.getXmlOptions()));
+        //System.out.println(encoded.xmlText(encoder.getXmlOptions()));
         assertThat(encoded, instanceOf(TrajectoryObservationType.class));
     }
 
@@ -136,7 +136,7 @@ public class TrajectoryObservationTypeEncoderTest extends AbtractProcessDecoding
     public void test_multi_count() throws EncodingException, ParseException, DecodingException, XmlException, IOException {
         XmlObject encoded = encoder.encode(getCountObservation());
         assertThat(XmlHelper.validateDocument(encoded), is(TRUE));
-        System.out.println(encoded.xmlText(encoder.getXmlOptions()));
+        //System.out.println(encoded.xmlText(encoder.getXmlOptions()));
         assertThat(encoded, instanceOf(TrajectoryObservationType.class));
     }
 
@@ -144,7 +144,7 @@ public class TrajectoryObservationTypeEncoderTest extends AbtractProcessDecoding
     public void test_multi_categoy() throws EncodingException, ParseException, DecodingException, XmlException, IOException {
         XmlObject encoded = encoder.encode(getCategoricalObservation());
         assertThat(XmlHelper.validateDocument(encoded), is(TRUE));
-        System.out.println(encoded.xmlText(encoder.getXmlOptions()));
+        //System.out.println(encoded.xmlText(encoder.getXmlOptions()));
         assertThat(encoded, instanceOf(TrajectoryObservationType.class));
     }
 

--- a/svalbard/xmlbeans/src/test/java/org/n52/svalbard/encode/TsmlTVPEncoderv10Test.java
+++ b/svalbard/xmlbeans/src/test/java/org/n52/svalbard/encode/TsmlTVPEncoderv10Test.java
@@ -155,8 +155,8 @@ public class TsmlTVPEncoderv10Test {
 
         XmlObject encodedElement = encoder.encode(mv);
 
-        Assert.assertThat(((TimeseriesMetadataType) ((TimeseriesTVPDocument) encodedElement)
-                .getTimeseriesTVP().getMetadata().getTimeseriesMetadata()).getCumulative(), Is.is(true));
+        Assert.assertThat(((TimeseriesTVPDocument) encodedElement).getTimeseriesTVP()
+                .getMetadata().getTimeseriesMetadata().getCumulative(), Is.is(true));
     }
 
     @Test

--- a/svalbard/xmlstream/pom.xml
+++ b/svalbard/xmlstream/pom.xml
@@ -45,6 +45,14 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/svalbard/xmlstream/src/main/java/org/n52/svalbard/read/NillableReader.java
+++ b/svalbard/xmlstream/src/main/java/org/n52/svalbard/read/NillableReader.java
@@ -31,6 +31,8 @@ import org.n52.svalbard.decode.exception.DecodingException;
 import com.google.common.base.Optional;
 import com.google.common.collect.Iterables;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * TODO JavaDoc
  *
@@ -47,13 +49,14 @@ public abstract class NillableReader<T> extends XmlReader<Nillable<T>> {
     }
 
     @Override
-    protected void begin()
-            throws XMLStreamException, DecodingException {
+    @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION")
+    protected void begin() throws XMLStreamException, DecodingException {
         Optional<String> attr = attr(W3CConstants.QN_XSI_NIL);
         if (attr.isPresent() && attr.get().equals("true")) {
             List<QName> attributeNames = getPossibleNilReasonAttributes();
             Iterable<Optional<String>> attributes = attr(attributeNames);
             Iterable<String> reasons = Optional.presentInstances(attributes);
+
             this.nillable = Nillable.nil(Iterables.getFirst(reasons, null));
         } else {
             this.nillable = Nillable.of(delegate(getDelegate()));

--- a/svalbard/xmlstream/src/main/java/org/n52/svalbard/write/OmV20XmlStreamWriter.java
+++ b/svalbard/xmlstream/src/main/java/org/n52/svalbard/write/OmV20XmlStreamWriter.java
@@ -26,7 +26,7 @@ import org.n52.shetland.ogc.om.features.SfConstants;
 import org.n52.svalbard.encode.EncodingContext;
 
 /**
- * Implementation of {@link AbstractOmV20XmlStreamWriter} to write O&M 2.0
+ * Implementation of {@link AbstractOmV20XmlStreamWriter} to write O&amp;M 2.0
  * encoded {@link OmObservation}s to stream
  *
  * @author <a href="mailto:c.hollmann@52north.org">Carsten Hollmann</a>

--- a/svalbard/xmlstream/src/main/java/org/n52/svalbard/write/TsmlTVPEncoderv10XmlStreamWriter.java
+++ b/svalbard/xmlstream/src/main/java/org/n52/svalbard/write/TsmlTVPEncoderv10XmlStreamWriter.java
@@ -20,7 +20,7 @@ import java.io.OutputStream;
 import java.util.List;
 import java.util.Optional;
 
-
+import javax.annotation.Nullable;
 import javax.xml.stream.XMLStreamException;
 
 import org.apache.commons.lang.StringEscapeUtils;
@@ -53,21 +53,19 @@ import org.n52.svalbard.encode.exception.EncodingException;
 import com.google.common.base.Strings;
 
 /**
- * TODO(specki): update javadoc
- * Implementation of {@link AbstractOmV20XmlStreamWriter} to write WaterML 2.0
- * encoded {@link OmObservation}s to stream
+ * TODO(specki): update javadoc Implementation of {@link AbstractOmV20XmlStreamWriter} to write WaterML 2.0 encoded
+ * {@link OmObservation}s to stream
  *
  * @since 1.0.0
  *
  */
-
 public class TsmlTVPEncoderv10XmlStreamWriter
         extends AbstractOmV20XmlStreamWriter {
     public TsmlTVPEncoderv10XmlStreamWriter(
             EncodingContext context,
             OutputStream outputStream,
             OmObservation element)
-                    throws XMLStreamException {
+            throws XMLStreamException {
         super(context, outputStream, element);
     }
 
@@ -103,12 +101,13 @@ public class TsmlTVPEncoderv10XmlStreamWriter
             if (observationValue.isSetUnit()) {
                 writeDefaultPointMetadata(observationValue, observationValue.getUnit());
             } else if (observation.getObservationConstellation()
-                    .getObservableProperty() instanceof OmObservableProperty
-                    && ((OmObservableProperty) observation.getObservationConstellation().getObservableProperty())
-                            .isSetUnit()) {
+                    .getObservableProperty() instanceof OmObservableProperty &&
+                       ((OmObservableProperty) observation.getObservationConstellation().getObservableProperty())
+                               .isSetUnit()) {
                 writeDefaultPointMetadata(observationValue,
-                        ((OmObservableProperty) observation.getObservationConstellation().getObservableProperty())
-                                .getUnit());
+                                          ((OmObservableProperty) observation.getObservationConstellation()
+                                                  .getObservableProperty())
+                                                  .getUnit());
             } else {
                 writeDefaultPointMetadata(observationValue, null);
             }
@@ -165,8 +164,7 @@ public class TsmlTVPEncoderv10XmlStreamWriter
     /**
      * Close written wml:MeasurementTimeseriesML and om:result tags
      *
-     * @throws XMLStreamException
-     *             If an error occurs when writing to stream
+     * @throws XMLStreamException If an error occurs when writing to stream
      */
     private void close() throws XMLStreamException {
         end(TimeseriesMLConstants.QN_MEASUREMENT_TIMESERIES);
@@ -176,19 +174,17 @@ public class TsmlTVPEncoderv10XmlStreamWriter
     /**
      * Write timeseries metadata to stream
      *
-     * @param id
-     *            Observation id
+     * @param o the observation
      *
-     * @throws XMLStreamException
-     *             If an error occurs when writing to stream
+     * @throws XMLStreamException If an error occurs when writing to stream
      */
     private void writeMeasurementTimeseriesMLMetadata(OmObservation o) throws XMLStreamException {
         start(TimeseriesMLConstants.QN_METADATA);
         start(TimeseriesMLConstants.QN_MEASUREMENT_TIMESERIES_METADATA);
         empty(TimeseriesMLConstants.QN_TEMPORAL_EXTENT);
         addXlinkHrefAttr("#" + o.getPhenomenonTime().getGmlId());
-        if (o.isSetValue() && o.getValue().isSetMetadata() && o.getValue().getMetadata().isSetTimeseriesMetadata()
-                && o.getValue().getMetadata().getTimeseriesmetadata() instanceof MeasurementTimeseriesMetadata) {
+        if (o.isSetValue() && o.getValue().isSetMetadata() && o.getValue().getMetadata().isSetTimeseriesMetadata() &&
+            o.getValue().getMetadata().getTimeseriesmetadata() instanceof MeasurementTimeseriesMetadata) {
             start(TimeseriesMLConstants.QN_CUMULATIVE);
             chars(Boolean.toString(((MeasurementTimeseriesMetadata) o.getValue().getMetadata().getTimeseriesmetadata())
                     .isCumulative()));
@@ -201,13 +197,13 @@ public class TsmlTVPEncoderv10XmlStreamWriter
     /**
      * Write wml:defaultPointMetadata to stream
      *
-     * @param unit
-     *            the unit
+     * @param value the observation value
+     * @param unit  the unit
      *
-     * @throws XMLStreamException
-     *             If an error occurs when writing to stream
+     * @throws XMLStreamException If an error occurs when writing to stream
      */
-    private void writeDefaultPointMetadata(ObservationValue<?> value, String unit) throws XMLStreamException {
+    private void writeDefaultPointMetadata(@Nullable ObservationValue<?> value, @Nullable String unit)
+            throws XMLStreamException {
         start(TimeseriesMLConstants.QN_DEFAULT_POINT_METADATA);
         start(TimeseriesMLConstants.QN_DEFAULT_TVP_MEASUREMENT_METADATA);
         writeUOM(unit);
@@ -219,14 +215,12 @@ public class TsmlTVPEncoderv10XmlStreamWriter
     /**
      * Write UOM attribute to stream
      *
-     * @param code
-     *            UOM code
+     * @param code UOM code
      *
-     * @throws XMLStreamException
-     *             If an error occurs when writing to stream
+     * @throws XMLStreamException If an error occurs when writing to stream
      */
-    private void writeUOM(String code) throws XMLStreamException {
-        if (!Strings.isNullOrEmpty(code)) {
+    private void writeUOM(@Nullable String code) throws XMLStreamException {
+        if (code != null && !code.isEmpty()) {
             empty(TimeseriesMLConstants.UOM);
             attr("code", code);
         }
@@ -235,19 +229,19 @@ public class TsmlTVPEncoderv10XmlStreamWriter
     /**
      * Write wml:interpolationType to stream
      *
-     * @throws XMLStreamException
-     *             If an error occurs when writing to stream
+     * @param value the value
+     *
+     * @throws XMLStreamException If an error occurs when writing to stream
      */
-    private void writeInterpolationType(ObservationValue<?> value) throws XMLStreamException {
+    private void writeInterpolationType(@Nullable ObservationValue<?> value) throws XMLStreamException {
         empty(TimeseriesMLConstants.QN_INTERPOLATION_TYPE);
-        if (value != null && value.isSetMetadata()
-                && value.getDefaultPointMetadata().isSetDefaultTVPMeasurementMetadata()
-                && value.getDefaultPointMetadata().getDefaultTVPMeasurementMetadata().isSetInterpolationType()) {
-            InterpolationType interpolationtype =
-                        (InterpolationType) value
-                            .getDefaultPointMetadata()
-                            .getDefaultTVPMeasurementMetadata()
-                            .getInterpolationtype();
+        if (value != null && value.isSetMetadata() &&
+            value.getDefaultPointMetadata().isSetDefaultTVPMeasurementMetadata() &&
+            value.getDefaultPointMetadata().getDefaultTVPMeasurementMetadata().isSetInterpolationType()) {
+            InterpolationType interpolationtype = (InterpolationType) value
+                    .getDefaultPointMetadata()
+                    .getDefaultTVPMeasurementMetadata()
+                    .getInterpolationtype();
             addXlinkHrefAttr(interpolationtype.getIdentifier());
             addXlinkTitleAttr(interpolationtype.getTitle());
         } else {
@@ -259,8 +253,7 @@ public class TsmlTVPEncoderv10XmlStreamWriter
     /**
      * Get the {@link String} representation of {@link Value}
      *
-     * @param value
-     *            {@link Value} to get {@link String} representation from
+     * @param value {@link Value} to get {@link String} representation from
      *
      * @return {@link String} representation of {@link Value}
      */
@@ -289,13 +282,10 @@ public class TsmlTVPEncoderv10XmlStreamWriter
     /**
      * Write wml:point to stream
      *
-     * @param time
-     *            time as {@link String}
-     * @param value
-     *            value as {@link String}
+     * @param time  time as {@link String}
+     * @param value value as {@link String}
      *
-     * @throws XMLStreamException
-     *             If an error occurs when writing to stream
+     * @throws XMLStreamException If an error occurs when writing to stream
      */
     private void writePoint(String time, String value) throws XMLStreamException {
         if (!Strings.isNullOrEmpty(time)) {
@@ -308,13 +298,10 @@ public class TsmlTVPEncoderv10XmlStreamWriter
     /**
      * Write wml:MeasurementTVP to stream
      *
-     * @param time
-     *            time as {@link String}
-     * @param value
-     *            value as {@link String}
+     * @param time  time as {@link String}
+     * @param value value as {@link String}
      *
-     * @throws XMLStreamException
-     *             If an error occurs when writing to stream
+     * @throws XMLStreamException If an error occurs when writing to stream
      */
     private void writeMeasurementTVP(String time, String value) throws XMLStreamException {
         start(TimeseriesMLConstants.QN_MEASUREMENT_TVP);
@@ -326,11 +313,9 @@ public class TsmlTVPEncoderv10XmlStreamWriter
     /**
      * Write wml:time to stream
      *
-     * @param time
-     *            time to write
+     * @param time time to write
      *
-     * @throws XMLStreamException
-     *             If an error occurs when writing to stream
+     * @throws XMLStreamException If an error occurs when writing to stream
      */
     private void writeTime(String time) throws XMLStreamException {
         start(TimeseriesMLConstants.QN_TIME);
@@ -341,11 +326,9 @@ public class TsmlTVPEncoderv10XmlStreamWriter
     /**
      * Write wml:value to stream
      *
-     * @param value
-     *            value to write
+     * @param value value to write
      *
-     * @throws XMLStreamException
-     *             If an error occurs when writing to stream
+     * @throws XMLStreamException If an error occurs when writing to stream
      */
     private void writeValue(String value) throws XMLStreamException {
         if (!Strings.isNullOrEmpty(value)) {
@@ -362,8 +345,7 @@ public class TsmlTVPEncoderv10XmlStreamWriter
     /**
      * Write missing value metadata to stream
      *
-     * @throws XMLStreamException
-     *             If an error occurs when writing to stream
+     * @throws XMLStreamException If an error occurs when writing to stream
      */
     private void writeValueMetadata() throws XMLStreamException {
         start(TimeseriesMLConstants.QN_METADATA);

--- a/svalbard/xmlstream/src/main/java/org/n52/svalbard/write/WmlTVPEncoderv20XmlStreamWriter.java
+++ b/svalbard/xmlstream/src/main/java/org/n52/svalbard/write/WmlTVPEncoderv20XmlStreamWriter.java
@@ -20,6 +20,7 @@ import java.io.OutputStream;
 import java.util.List;
 import java.util.Optional;
 
+import javax.annotation.Nullable;
 import javax.xml.stream.XMLStreamException;
 
 import org.apache.commons.lang.StringEscapeUtils;
@@ -52,8 +53,7 @@ import org.n52.svalbard.encode.exception.EncodingException;
 import com.google.common.base.Strings;
 
 /**
- * Implementation of {@link AbstractOmV20XmlStreamWriter} to write WaterML 2.0
- * encoded {@link OmObservation}s to stream
+ * Implementation of {@link AbstractOmV20XmlStreamWriter} to write WaterML 2.0 encoded {@link OmObservation}s to stream
  *
  * @author <a href="mailto:c.hollmann@52north.org">Carsten Hollmann</a>
  * @since 1.0.0
@@ -65,7 +65,7 @@ public class WmlTVPEncoderv20XmlStreamWriter
             EncodingContext context,
             OutputStream outputStream,
             OmObservation element)
-                    throws XMLStreamException {
+            throws XMLStreamException {
         super(context, outputStream, element);
     }
 
@@ -101,12 +101,13 @@ public class WmlTVPEncoderv20XmlStreamWriter
             if (observationValue.isSetUnit()) {
                 writeDefaultPointMetadata(observationValue, observationValue.getUnit());
             } else if (observation.getObservationConstellation()
-                    .getObservableProperty() instanceof OmObservableProperty
-                    && ((OmObservableProperty) observation.getObservationConstellation().getObservableProperty())
-                            .isSetUnit()) {
+                    .getObservableProperty() instanceof OmObservableProperty &&
+                     ((OmObservableProperty) observation.getObservationConstellation().getObservableProperty())
+                               .isSetUnit()) {
                 writeDefaultPointMetadata(observationValue,
-                        ((OmObservableProperty) observation.getObservationConstellation().getObservableProperty())
-                                .getUnit());
+                                          ((OmObservableProperty) observation.getObservationConstellation()
+                                                  .getObservableProperty())
+                                                  .getUnit());
             } else {
                 writeDefaultPointMetadata(observationValue, null);
             }
@@ -163,8 +164,7 @@ public class WmlTVPEncoderv20XmlStreamWriter
     /**
      * Close written wml:MeasurementTimeseries and om:result tags
      *
-     * @throws XMLStreamException
-     *             If an error occurs when writing to stream
+     * @throws XMLStreamException If an error occurs when writing to stream
      */
     private void close() throws XMLStreamException {
         end(WaterMLConstants.QN_MEASUREMENT_TIMESERIES);
@@ -174,19 +174,17 @@ public class WmlTVPEncoderv20XmlStreamWriter
     /**
      * Write timeseries metadata to stream
      *
-     * @param id
-     *            Observation id
+     * @param id Observation id
      *
-     * @throws XMLStreamException
-     *             If an error occurs when writing to stream
+     * @throws XMLStreamException If an error occurs when writing to stream
      */
     private void writeMeasurementTimeseriesMetadata(OmObservation o) throws XMLStreamException {
         start(WaterMLConstants.QN_METADATA);
         start(WaterMLConstants.QN_MEASUREMENT_TIMESERIES_METADATA);
         empty(WaterMLConstants.QN_TEMPORAL_EXTENT);
         addXlinkHrefAttr("#" + o.getPhenomenonTime().getGmlId());
-        if (o.isSetValue() && o.getValue().isSetMetadata() && o.getValue().getMetadata().isSetTimeseriesMetadata()
-                && o.getValue().getMetadata().getTimeseriesmetadata() instanceof MeasurementTimeseriesMetadata) {
+        if (o.isSetValue() && o.getValue().isSetMetadata() && o.getValue().getMetadata().isSetTimeseriesMetadata() &&
+                 o.getValue().getMetadata().getTimeseriesmetadata() instanceof MeasurementTimeseriesMetadata) {
             start(WaterMLConstants.QN_CUMULATIVE);
             chars(Boolean.toString(((MeasurementTimeseriesMetadata) o.getValue().getMetadata().getTimeseriesmetadata())
                     .isCumulative()));
@@ -199,13 +197,13 @@ public class WmlTVPEncoderv20XmlStreamWriter
     /**
      * Write wml:defaultPointMetadata to stream
      *
-     * @param unit
-     *            the unit
+     * @param value the observation value
+     * @param unit the unit
      *
-     * @throws XMLStreamException
-     *             If an error occurs when writing to stream
+     * @throws XMLStreamException If an error occurs when writing to stream
      */
-    private void writeDefaultPointMetadata(ObservationValue<?> value, String unit) throws XMLStreamException {
+    private void writeDefaultPointMetadata(@Nullable ObservationValue<?> value, @Nullable String unit) throws
+            XMLStreamException {
         start(WaterMLConstants.QN_DEFAULT_POINT_METADATA);
         start(WaterMLConstants.QN_DEFAULT_TVP_MEASUREMENT_METADATA);
         writeUOM(unit);
@@ -217,14 +215,12 @@ public class WmlTVPEncoderv20XmlStreamWriter
     /**
      * Write UOM attribute to stream
      *
-     * @param code
-     *            UOM code
+     * @param code UOM code
      *
-     * @throws XMLStreamException
-     *             If an error occurs when writing to stream
+     * @throws XMLStreamException If an error occurs when writing to stream
      */
-    private void writeUOM(String code) throws XMLStreamException {
-        if (!Strings.isNullOrEmpty(code)) {
+    private void writeUOM(@Nullable String code) throws XMLStreamException {
+        if (code != null && !code.isEmpty()) {
             empty(WaterMLConstants.UOM);
             attr("code", code);
         }
@@ -233,19 +229,19 @@ public class WmlTVPEncoderv20XmlStreamWriter
     /**
      * Write wml:interpolationType to stream
      *
-     * @throws XMLStreamException
-     *             If an error occurs when writing to stream
+     * @param value the observation value
+     *
+     * @throws XMLStreamException If an error occurs when writing to stream
      */
-    private void writeInterpolationType(ObservationValue<?> value) throws XMLStreamException {
+    private void writeInterpolationType(@Nullable ObservationValue<?> value) throws XMLStreamException {
         empty(WaterMLConstants.QN_INTERPOLATION_TYPE);
-        if (value != null && value.isSetMetadata()
-                && value.getDefaultPointMetadata().isSetDefaultTVPMeasurementMetadata()
-                && value.getDefaultPointMetadata().getDefaultTVPMeasurementMetadata().isSetInterpolationType()) {
-            InterpolationType interpolationtype =
-                        (InterpolationType) value
-                            .getDefaultPointMetadata()
-                            .getDefaultTVPMeasurementMetadata()
-                            .getInterpolationtype();
+        if (value != null && value.isSetMetadata() &&
+                 value.getDefaultPointMetadata().isSetDefaultTVPMeasurementMetadata() &&
+                 value.getDefaultPointMetadata().getDefaultTVPMeasurementMetadata().isSetInterpolationType()) {
+            InterpolationType interpolationtype = (InterpolationType) value
+                    .getDefaultPointMetadata()
+                    .getDefaultTVPMeasurementMetadata()
+                    .getInterpolationtype();
             addXlinkHrefAttr(interpolationtype.getIdentifier());
             addXlinkTitleAttr(interpolationtype.getTitle());
         } else {
@@ -257,8 +253,7 @@ public class WmlTVPEncoderv20XmlStreamWriter
     /**
      * Get the {@link String} representation of {@link Value}
      *
-     * @param value
-     *            {@link Value} to get {@link String} representation from
+     * @param value {@link Value} to get {@link String} representation from
      *
      * @return {@link String} representation of {@link Value}
      */
@@ -287,13 +282,10 @@ public class WmlTVPEncoderv20XmlStreamWriter
     /**
      * Write wml:point to stream
      *
-     * @param time
-     *            time as {@link String}
-     * @param value
-     *            value as {@link String}
+     * @param time time as {@link String}
+     * @param value value as {@link String}
      *
-     * @throws XMLStreamException
-     *             If an error occurs when writing to stream
+     * @throws XMLStreamException If an error occurs when writing to stream
      */
     private void writePoint(String time, String value) throws XMLStreamException {
         if (!Strings.isNullOrEmpty(time)) {
@@ -306,13 +298,10 @@ public class WmlTVPEncoderv20XmlStreamWriter
     /**
      * Write wml:MeasurementTVP to stream
      *
-     * @param time
-     *            time as {@link String}
-     * @param value
-     *            value as {@link String}
+     * @param time time as {@link String}
+     * @param value value as {@link String}
      *
-     * @throws XMLStreamException
-     *             If an error occurs when writing to stream
+     * @throws XMLStreamException If an error occurs when writing to stream
      */
     private void writeMeasurementTVP(String time, String value) throws XMLStreamException {
         start(WaterMLConstants.QN_MEASUREMENT_TVP);
@@ -324,11 +313,9 @@ public class WmlTVPEncoderv20XmlStreamWriter
     /**
      * Write wml:time to stream
      *
-     * @param time
-     *            time to write
+     * @param time time to write
      *
-     * @throws XMLStreamException
-     *             If an error occurs when writing to stream
+     * @throws XMLStreamException If an error occurs when writing to stream
      */
     private void writeTime(String time) throws XMLStreamException {
         start(WaterMLConstants.QN_TIME);
@@ -339,11 +326,9 @@ public class WmlTVPEncoderv20XmlStreamWriter
     /**
      * Write wml:value to stream
      *
-     * @param value
-     *            value to write
+     * @param value value to write
      *
-     * @throws XMLStreamException
-     *             If an error occurs when writing to stream
+     * @throws XMLStreamException If an error occurs when writing to stream
      */
     private void writeValue(String value) throws XMLStreamException {
         if (!Strings.isNullOrEmpty(value)) {
@@ -360,8 +345,7 @@ public class WmlTVPEncoderv20XmlStreamWriter
     /**
      * Write missing value metadata to stream
      *
-     * @throws XMLStreamException
-     *             If an error occurs when writing to stream
+     * @throws XMLStreamException If an error occurs when writing to stream
      */
     private void writeValueMetadata() throws XMLStreamException {
         start(WaterMLConstants.QN_METADATA);

--- a/svalbard/xmlstream/src/test/java/org/n52/svalbard/write/EReportingHeaderEncoderTest.java
+++ b/svalbard/xmlstream/src/test/java/org/n52/svalbard/write/EReportingHeaderEncoderTest.java
@@ -168,7 +168,7 @@ public class EReportingHeaderEncoderTest {
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
             new EReportingHeaderEncoder(EncodingContext.of(EncoderFlags.ENCODER_REPOSITORY, new EncoderRepository()),
                     baos, header).write();
-            System.out.println(baos.toString("UTF-8"));
+            //System.out.println(baos.toString("UTF-8"));
             // xmlValidation(baos);
         }
     }

--- a/svalbard/xmlstream/src/test/java/org/n52/svalbard/write/IndentingXmlStreamWriterTest.java
+++ b/svalbard/xmlstream/src/test/java/org/n52/svalbard/write/IndentingXmlStreamWriterTest.java
@@ -101,8 +101,8 @@ public class IndentingXmlStreamWriterTest {
                           "    </wrapper1>\n" +
                           "</document>";
 
-        System.out.println(baos.toString("UTF-8"));
-        System.out.println(expected);
+        //System.out.println(baos.toString("UTF-8"));
+        //System.out.println(expected);
         Assert.assertThat(baos.toString("UTF-8"), is(expected));
     }
 


### PR DESCRIPTION
Todo:
* [ ] Find a solution for additional dependencies to be declared depending on the runtime JRE
* [ ] Fix the `maven-notice-plugin` to read the license mappings with the right namespace
* [ ] JavaDoc generation currently fails:
    ```
    [INFO] --- maven-javadoc-plugin:3.0.1:jar (default) @ shetland ---
    [ERROR] Error fetching link: /home/autermann/Source/arctic-sea/janmayen/target/apidocs/package-list. Ignored it.
    ```
* [x] Fix the OpenJDK/OracleJDK 10 problem with the certificate of sonatype-snapshots