### PR TITLE
Allow minoccurrence of zero (i.e. optional inputs)

### DIFF
--- a/shetland/src/main/java/org/n52/shetland/ogc/wps/description/impl/AbstractProcessInputDescription.java
+++ b/shetland/src/main/java/org/n52/shetland/ogc/wps/description/impl/AbstractProcessInputDescription.java
@@ -77,7 +77,7 @@ public abstract class AbstractProcessInputDescription extends AbstractDataDescri
         @Override
         public B withMinimalOccurence(BigInteger min) {
             if (min != null) {
-                Preconditions.checkArgument(min.compareTo(BigInteger.ZERO) > 0, "minimalOccurence");
+                Preconditions.checkArgument(min.compareTo(BigInteger.ZERO) >= 0, "minimalOccurence");
                 this.minimalOccurence = min;
             } else {
                 this.minimalOccurence = BigInteger.ONE;


### PR DESCRIPTION
If the minimal occurrence of a WPS input can only be bigger than zero, no optional inputs are possible. Changed the check from bigger to bigger or equal to zero.