### PR TITLE
Extend support for language strings

### DIFF
--- a/janmayen/pom.xml
+++ b/janmayen/pom.xml
@@ -78,6 +78,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter-engine</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>

--- a/janmayen/src/main/java/org/n52/janmayen/i18n/LocaleHelper.java
+++ b/janmayen/src/main/java/org/n52/janmayen/i18n/LocaleHelper.java
@@ -74,7 +74,9 @@ public final class LocaleHelper {
     }
 
     private static Locale decode1(String locale) {
-        String[] tokens = locale.split("[-_# ]");
+        String strippedQualifiers = stripQualityFactorWeights(locale);
+        String firstLanguage = getFirstLanguageCode(strippedQualifiers);
+        String[] tokens = firstLanguage.split("[-_# ]");
         if (tokens.length > 3) {
             throw new IllegalArgumentException("Unparsable language parameter: " + locale);
         }
@@ -84,6 +86,24 @@ public final class LocaleHelper {
         country = ISO_COUNTRY_ALPHA_3_TO_ALPHA_2.getOrDefault(country, country);
         language = ISO_LANGUAGE_ALPHA_3_TO_ALPHA_2.getOrDefault(language, language);
         return new Locale(language, country, variant);
+    }
+
+    /**
+     * Strips quality factors weights after semicolon, e.g. {@code de-DE,de;q=0.9}.
+     * 
+     * @param locale the locale potentially containing quality factor weights
+     * @return the locale without quality factor weights
+     */
+    private static String stripQualityFactorWeights(String locale) {
+        int semicolonIndex = locale.indexOf(";");
+        boolean hasQualityFactorWeights = semicolonIndex != -1;
+        return hasQualityFactorWeights 
+                ? locale.substring(0, semicolonIndex)
+                : locale;
+    }
+
+    private static String getFirstLanguageCode(String locale) {
+        return locale.split(",")[0];
     }
 
     private static String checkForIsoB(String language) {

--- a/janmayen/src/test/java/org/n52/janmayen/i18n/LocaleHelperTest.java
+++ b/janmayen/src/test/java/org/n52/janmayen/i18n/LocaleHelperTest.java
@@ -53,4 +53,33 @@ public class LocaleHelperTest {
         assertThat(LocaleHelper.decode("ger", null), is(Locale.GERMAN));
         assertThat(LocaleHelper.decode("eng", null), is(Locale.ENGLISH));
     }
+
+    @Test
+    public void parseFirstOfMultipleLanguages() {
+        String multiLanguageString = "de-DE,en";
+        Locale locale = LocaleHelper.decode(multiLanguageString);
+        assertThat(locale, is(Locale.GERMANY));
+    }
+
+    @Test
+    public void parseWithEmptyRelativeQualityFactors() {
+        String headerWithQualityFactors = "de-DE;";
+        Locale locale = LocaleHelper.decode(headerWithQualityFactors);
+        assertThat(locale, is(Locale.GERMANY));
+    }
+
+    @Test
+    public void parseWithSingleRelativeQualityFactors() {
+        String headerWithQualityFactors = "de-DE;q=0.9";
+        Locale locale = LocaleHelper.decode(headerWithQualityFactors);
+        assertThat(locale, is(Locale.GERMANY));
+    }
+
+    @Test
+    public void parseWithMultipleRelativeQualityFactors() {
+        String headerWithQualityFactors = "de-DE,en;q=0.9,en-GB;q=0.8,en;q=0.7,en-US;q=0.6";
+        Locale locale = LocaleHelper.decode(headerWithQualityFactors);
+        assertThat(locale, is(Locale.GERMANY));
+    }
+
 }


### PR DESCRIPTION
Parsing language strings is restricted to only one language. In
addition, only languages withoug q-factor weights are supported.
However, problems arise when browsers send header like this

  Accept-Language: fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5

Parsing would not result as language locale fr-CH.

This change extends parsing by stripping both potentially further
languages separated by a comma (e.g. de_DE,de) and the first one
only is being used. If the first one fails no further parsing is
done. Quality weights (e.g. de_DE;q=0.9) are stripped completely.