### PR TITLE
Fix $expand parser not rewriting if queryOptions are specified

### DIFF
--- a/svalbard/odata/src/main/java/org/n52/svalbard/odata/core/STAQueryOptionVisitor.java
+++ b/svalbard/odata/src/main/java/org/n52/svalbard/odata/core/STAQueryOptionVisitor.java
@@ -247,7 +247,8 @@ public class STAQueryOptionVisitor extends STAQueryOptionsGrammarBaseVisitor {
     }
 
     // Rewrite slash to normal expand systemQueryOption
-    private ExpandItem handleSlashRewrite(STAQueryOptionsGrammar.ExpandItemContext ctx, QueryOptions base) {
+    private ExpandItem handleSlashRewrite(STAQueryOptionsGrammar.ExpandItemContext ctx, QueryOptions baseref) {
+        QueryOptions base = baseref;
         if (!ctx.memberExpr().SLASH().isEmpty()) {
             for (int i = ctx.memberExpr().ALPHAPLUS().size() - 1; i >= 1; i--) {
                 ExpandItem expandItem = new ExpandItem(ctx.memberExpr().ALPHAPLUS(i).getText(), base);

--- a/svalbard/odata/src/main/java/org/n52/svalbard/odata/core/STAQueryOptionVisitor.java
+++ b/svalbard/odata/src/main/java/org/n52/svalbard/odata/core/STAQueryOptionVisitor.java
@@ -254,10 +254,8 @@ public class STAQueryOptionVisitor extends STAQueryOptionsGrammarBaseVisitor {
                 ExpandFilter expandFilter = new ExpandFilter(expandItem);
                 base = new QueryOptions("", Collections.singleton(expandFilter));
             }
-            return new ExpandItem(ctx.memberExpr().ALPHAPLUS(0).getText(), base);
-        } else {
-            return new ExpandItem(ctx.getText(), base);
         }
+        return new ExpandItem(ctx.memberExpr().ALPHAPLUS(0).getText(), base);
     }
 
     @Override public FilterFilter visitFilter(STAQueryOptionsGrammar.FilterContext ctx) {

--- a/svalbard/odata/src/test/java/org/n52/svalbard/odata/core/ExpandQueryOptionTest.java
+++ b/svalbard/odata/src/test/java/org/n52/svalbard/odata/core/ExpandQueryOptionTest.java
@@ -232,15 +232,18 @@ public class ExpandQueryOptionTest extends QueryOptionTests {
      */
     @Test
     public void complexExpandOptionRewrite() {
+        QueryOptions options;
+        Set<ExpandItem> items;
+
         init(ODataConstants.QueryOptions.EXPAND
                      + EQ
                      + "Datastreams/Sensors/Datastreams");
-        QueryOptions options =
+        options =
                 (QueryOptions) parser.queryOptions().accept(new STAQueryOptionVisitor());
         Assertions.assertTrue(options.hasExpandFilter());
         Assertions.assertTrue(options.getExpandFilter() instanceof ExpandFilter);
 
-        Set<ExpandItem> items = (options.getExpandFilter().getItems());
+        items = (options.getExpandFilter().getItems());
 
         Assertions.assertNotNull(items);
         Assertions.assertEquals(1, items.size());
@@ -371,6 +374,20 @@ public class ExpandQueryOptionTest extends QueryOptionTests {
             } else {
                 Assertions.fail("Did not find expected expandItem!");
             }
+        }
+
+        init(ODataConstants.QueryOptions.EXPAND
+                     + EQ
+                     + "Observations/FeatureOfInterest($select=id),Thing/Locations");
+        options = (QueryOptions) parser.queryOptions().accept(new STAQueryOptionVisitor());
+        Assertions.assertTrue(options.hasExpandFilter());
+        Assertions.assertTrue(options.getExpandFilter() instanceof ExpandFilter);
+
+        items = (options.getExpandFilter().getItems());
+
+        for (ExpandItem expandItem : items) {
+            // Assert that rewrite worked
+            Assertions.assertFalse(expandItem.getPath().contains("/"));
         }
     }
 


### PR DESCRIPTION
- Previously ExpandItems were only rewritten (removing the slash in
favor of nested queryOptions) when there were no queryOptions specified.