### PR TITLE
adjust scope of hamcrest to test

### DIFF
--- a/svalbard/json/pom.xml
+++ b/svalbard/json/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
-            <scope>compile</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
most likely a slip, but the `compile` scope breaks the build on some downstream projects which include the `dependency:analyze-only` goal.

local build still went smooth after the adjustment.