### PR TITLE
Fix GeoLiteral Lexer Mode not recognizing DOT as valid Token

### DIFF
--- a/svalbard/odata/src/main/antlr4/org/n52/svalbard/odata/grammar/STAQueryOptionsLexer.g4
+++ b/svalbard/odata/src/main/antlr4/org/n52/svalbard/odata/grammar/STAQueryOptionsLexer.g4
@@ -595,6 +595,10 @@ GEOLITERAL_OP
    : OP -> type (OP)
    ;
 
+GEOLITERAL_DOT
+   : DOT -> type (DOT)
+   ;
+
 GEOLITERAL_CP
    : CP -> type (CP)
    ;

--- a/svalbard/odata/src/main/java/org/n52/svalbard/odata/ODataFesParser.java
+++ b/svalbard/odata/src/main/java/org/n52/svalbard/odata/ODataFesParser.java
@@ -205,7 +205,6 @@ public class ODataFesParser
         GeometryFactory geometryFactory = new GeometryFactory(precisionModel, srid);
         WKTReader wktReader = new WKTReader(geometryFactory);
         try {
-
             return wktReader.read(value);
         } catch (ParseException ex) {
             throw invalidGeometry(val, ex);

--- a/svalbard/odata/src/test/java/org/n52/svalbard/odata/core/TestConstants.java
+++ b/svalbard/odata/src/test/java/org/n52/svalbard/odata/core/TestConstants.java
@@ -57,6 +57,7 @@ public interface TestConstants {
             "$filter=st_disjoint(location, geography'POLYGON ((30 10, 10 20, 20 40, 40 40, 30 10))')",
             "$filter=st_touches(location, geography'LINESTRING (30 10, 10 30, 40 40)')",
             "$filter=st_within(location, geography'POLYGON ((30 10, 10 20, 20 40, 40 40, 30 10))')",
+            "$filter=st_within(location, geography'POLYGON ((30.0 10.0, 10.0 20.0, 20.0 40.0, 40.0 40.0, 30.0 10.0))')",
             "$filter=st_overlaps(location, geography'POLYGON ((30 10, 10 20, 20 40, 40 40, 30 10))')",
             "$filter=st_crosses(location, geography'LINESTRING (30 10, 10 30, 40 40)')",
             "$filter=st_intersects(location, geography'LINESTRING (30 10, 10 30, 40 40)')",


### PR DESCRIPTION
This prevents Dots from being used in geoLiterals. Causes
https://github.com/52North/sensorweb-server-sta/issues/114