### PR TITLE
fix missing organizations tag in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,8 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -42,6 +43,11 @@
         <module>svalbard</module>
         <module>iceland</module>
     </modules>
+
+    <organization>
+        <name>52North Initiative for Geospatial Open Source Software GmbH</name>
+        <url>https://52north.org</url>
+    </organization>
 
     <developers>
         <developer>


### PR DESCRIPTION
The pom.xml is missing the `<organization>` tag that is referenced here: https://github.com/52North/arctic-sea/blob/616bc53ae393b1b5230542109acc6b795c6f2c16/pom.xml#L51

Effects can be seen here: https://search.maven.org/artifact/org.n52.arctic-sea/arctic-sea where *Developers* is not rendered properly