### PR TITLE
fix parsing of $count Query Option

### DIFF
--- a/svalbard/odata/src/main/java/org/n52/svalbard/odata/core/STAQueryOptionVisitor.java
+++ b/svalbard/odata/src/main/java/org/n52/svalbard/odata/core/STAQueryOptionVisitor.java
@@ -106,9 +106,12 @@ public class STAQueryOptionVisitor extends STAQueryOptionsGrammarBaseVisitor {
         return new SkipTopFilter(FilterConstants.SkipTopOperator.Top, Long.parseLong(ctx.decimalLiteral().getText()));
     }
 
-    //TODO: check if we would like to also allow $count=false in the url
     @Override public CountFilter visitCount(STAQueryOptionsGrammar.CountContext ctx) {
-        return new CountFilter(true);
+        if (ctx.False_LLC() != null) {
+            return new CountFilter(false);
+        } else {
+            return new CountFilter(true);
+        }
     }
 
     @Override public SelectFilter visitSelect(STAQueryOptionsGrammar.SelectContext ctx) {


### PR DESCRIPTION
$count was not actually parsed before and defaulted to true.